### PR TITLE
fix: repair release gate after update settings change

### DIFF
--- a/FinanceManager.Tests.Integration/UpdateControllerIntegrationTests.cs
+++ b/FinanceManager.Tests.Integration/UpdateControllerIntegrationTests.cs
@@ -53,7 +53,6 @@ public sealed class UpdateControllerIntegrationTests : IClassFixture<TestWebAppl
             "update.json",
             new TimeOnly(3, 30),
             "FinanceManagerService",
-            "financemanager",
             null,
             "updates",
             120);


### PR DESCRIPTION
Fixes the master release workflow after the update settings DTO changed from platform-specific service names to a single ServiceName. The integration test still used the old 11-argument UpdateSettingsUpdateRequest constructor.\n\nVerified locally:\n- dotnet test FinanceManager.Tests/FinanceManager.Tests.csproj --configuration Release --no-restore\n- dotnet test FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --configuration Release --no-restore