### PR TITLE
fix: Flaky ApiClientBackupsWithDemoDataTests durch DB-Locking-Race behoben

### DIFF
--- a/FinanceManager.Tests.Integration/TestWebApplicationFactory.cs
+++ b/FinanceManager.Tests.Integration/TestWebApplicationFactory.cs
@@ -72,13 +72,21 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
                 services.Remove(descriptor);
             }
 
-            // Create and open in-memory SQLite connection (shared cache to support multiple contexts)
-            _connection = new SqliteConnection("DataSource=:memory:;Cache=Shared");
+            // Use a uniquely-named shared-cache in-memory database (not a shared SqliteConnection object):
+            // a single SqliteConnection instance is not safe for concurrent use from multiple threads and
+            // causes "SQLite Error 5: database is locked" when the background task runner and an HTTP
+            // request thread access the database at the same time. Each AppDbContext instead opens its own
+            // connection against the same named in-memory database (Mode=Memory;Cache=Shared), which SQLite
+            // handles safely for concurrent access. The anchor connection below is kept open for the
+            // lifetime of the factory so the named in-memory database isn't dropped between uses.
+            var dbName = $"testdb_{Guid.NewGuid():N}";
+            var connectionString = $"Data Source={dbName};Mode=Memory;Cache=Shared";
+            _connection = new SqliteConnection(connectionString);
             _connection.Open();
 
             services.AddDbContext<AppDbContext>(options =>
             {
-                options.UseSqlite(_connection);
+                options.UseSqlite(connectionString);
             });
 
             // If a fixed time was requested by the test, replace the application's TimeProvider

--- a/FinanceManager.Tests.Integration/TestWebApplicationFactoryConcurrencyTests.cs
+++ b/FinanceManager.Tests.Integration/TestWebApplicationFactoryConcurrencyTests.cs
@@ -1,0 +1,57 @@
+using FinanceManager.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration;
+
+/// <summary>
+/// Reproduces a suspected concurrency issue in <see cref="TestWebApplicationFactory"/>, where multiple
+/// <see cref="AppDbContext"/> instances resolved from different threads all reuse the same externally-owned
+/// <see cref="Microsoft.Data.Sqlite.SqliteConnection"/> object, which is not safe for concurrent access.
+/// </summary>
+public class TestWebApplicationFactoryConcurrencyTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="TestWebApplicationFactoryConcurrencyTests"/>.
+    /// </summary>
+    /// <param name="factory">Shared test factory injected by xUnit's class fixture.</param>
+    public TestWebApplicationFactoryConcurrencyTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    /// <summary>
+    /// Runs several concurrent <see cref="AppDbContext"/> queries from different threads against the same
+    /// factory and asserts that no exception occurs.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentDbContextUsage_FromMultipleThreads_DoesNotThrow()
+    {
+        _ = _factory.Server; // force host startup
+
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        var tasks = Enumerable.Range(0, 8).Select(_ => Task.Run(async () =>
+        {
+            while (DateTime.UtcNow < deadline)
+            {
+                using var scope = _factory.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                _ = await db.Users.AsNoTracking().CountAsync();
+            }
+        })).ToArray();
+
+        var exceptions = new List<Exception>();
+        await Task.WhenAll(tasks.Select(async t =>
+        {
+            try { await t; }
+            catch (Exception ex) { lock (exceptions) { exceptions.Add(ex); } }
+        }));
+
+        exceptions.Should().BeEmpty("concurrent DbContext usage against the shared test-factory connection should not throw");
+    }
+}


### PR DESCRIPTION
## Zusammenfassung

- `TestWebApplicationFactory` teilte eine einzelne `SqliteConnection`-Instanz zwischen allen `AppDbContext`-Instanzen. Sqlite-Connections sind nicht threadsicher; sobald der Background-Task-Runner (Restore) und ein HTTP-Request-Thread (JWT-Auth-Validierung liest den Security-Stamp aus der DB) gleichzeitig zugriffen, schlug SQLite mit `database is locked` fehl.
- Das zeigte sich als sporadischer `500 Internal Server Error` in `Backups_GetStatusAsync`, u. a. in `ApiClientBackupsWithDemoDataTests.Backup_With_DemoData_Restore_Removes_NewlyCreatedContact` (auf `master` reproduziert, z. B. CI-Lauf vom 2026-07-20, Commit `975c9e8`).
- Fix: Jeder `AppDbContext` bekommt nun eine eigene Connection gegen eine benannte Shared-Cache-In-Memory-Datenbank (`Mode=Memory;Cache=Shared`); eine Anker-Connection hält die Datenbank für die Lebensdauer der Factory am Leben. SQLite handhabt konkurrierenden Zugriff über separate Connections auf dieselbe Shared-Cache-DB sicher, im Gegensatz zum parallelen Zugriff auf ein einzelnes Connection-Objekt.
- Neuer Regressionstest `TestWebApplicationFactoryConcurrencyTests.ConcurrentDbContextUsage_FromMultipleThreads_DoesNotThrow` reproduziert die Race direkt (schlug vor dem Fix zuverlässig mit `SQLite Error 5: database is locked` fehl, besteht danach).

## Test plan

- [x] Regressionstest schlägt vor dem Fix fehl, besteht danach
- [x] `FinanceManager.Tests.Integration` 3x hintereinander vollständig grün (98/98)
- [x] `FinanceManager.Tests` vollständig grün (874/874)
- [x] `dotnet build` der gesamten Solution ohne Fehler

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>