### PR TITLE
diag: Sichtbarkeit für sporadischen 500-Fehler in Release-Testgate verbessern

### DIFF
--- a/FinanceManager.Tests.Integration/TestWebApplicationFactoryConcurrencyTests.cs
+++ b/FinanceManager.Tests.Integration/TestWebApplicationFactoryConcurrencyTests.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.Users;
 using FinanceManager.Infrastructure;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -53,5 +54,46 @@ public class TestWebApplicationFactoryConcurrencyTests : IClassFixture<TestWebAp
         }));
 
         exceptions.Should().BeEmpty("concurrent DbContext usage against the shared test-factory connection should not throw");
+    }
+
+    /// <summary>
+    /// Runs several concurrent writes (insert + update) from different threads against the same factory
+    /// and asserts that no exception occurs. Reproduces "database is locked" errors that occur when
+    /// concurrent SQLite writers are not given a busy timeout to wait for each other.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentDbContextWrites_FromMultipleThreads_DoesNotThrow()
+    {
+        _ = _factory.Server; // force host startup
+
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        var tasks = Enumerable.Range(0, 8).Select(_ => Task.Run(async () =>
+        {
+            while (DateTime.UtcNow < deadline)
+            {
+                using var scope = _factory.Services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                var user = new User($"concurrency_{Guid.NewGuid():N}", isAdmin: false)
+                {
+                    SecurityStamp = Guid.NewGuid().ToString("N"),
+                    ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+                    PasswordHash = "not-a-real-hash",
+                };
+                db.Users.Add(user);
+                await db.SaveChangesAsync();
+
+                user.SecurityStamp = Guid.NewGuid().ToString("N");
+                await db.SaveChangesAsync();
+            }
+        })).ToArray();
+
+        var exceptions = new List<Exception>();
+        await Task.WhenAll(tasks.Select(async t =>
+        {
+            try { await t; }
+            catch (Exception ex) { lock (exceptions) { exceptions.Add(ex); } }
+        }));
+
+        exceptions.Should().BeEmpty("concurrent SQLite writers against the shared test-factory database should wait for each other instead of failing with 'database is locked'");
     }
 }

--- a/FinanceManager.Tests.Integration/UpdateControllerIntegrationTests.cs
+++ b/FinanceManager.Tests.Integration/UpdateControllerIntegrationTests.cs
@@ -236,7 +236,11 @@ public sealed class UpdateControllerIntegrationTests : IClassFixture<TestWebAppl
             username = TestWebApplicationFactory.BootstrapAdminUsername,
             password = TestWebApplicationFactory.BootstrapAdminPassword
         });
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            throw new InvalidOperationException($"Admin login failed with {(int)response.StatusCode} {response.StatusCode}: {body}");
+        }
     }
 
     private sealed class ThrowingUpdateOrchestrator : IUpdateOrchestrator

--- a/FinanceManager.Web/ProgramExtensions.cs
+++ b/FinanceManager.Web/ProgramExtensions.cs
@@ -353,9 +353,17 @@ namespace FinanceManager.Web
             {
                 app.UseExceptionHandler("/Error", createScopeForErrors: true);
             }
-            else if (!app.Configuration.GetValue<bool>("E2E:DisableHttpsRedirection"))
+            else
             {
-                app.UseHttpsRedirection();
+                // Surfaces the real exception (stack trace in the response body) instead of a bare,
+                // bodyless 500, which otherwise made unhandled exceptions during local development and
+                // integration tests (both run with Environment=Development) impossible to diagnose.
+                app.UseDeveloperExceptionPage();
+
+                if (!app.Configuration.GetValue<bool>("E2E:DisableHttpsRedirection"))
+                {
+                    app.UseHttpsRedirection();
+                }
             }
 
             app.Use(async (context, next) =>


### PR DESCRIPTION
## Kontext

Der Release-Workflow schlug zweimal auf CI (`master`) mit `UpdateSettings_RoundTripsForAdmin` fehl (`HttpRequestException: 500` beim Admin-Login in `AuthenticateAdminAsync`). Lokal ist der Fehler nicht reproduzierbar:

- 5x `FinanceManager.Tests.Integration` in Release-Konfiguration vollständig grün
- Gezielter Schreib-Nebenläufigkeits-Stresstest (`ConcurrentDbContextWrites_FromMultipleThreads_DoesNotThrow`, neu hinzugefügt) ebenfalls grün — die zuvor behobene DB-Locking-Ursache (PR #211) ist also nicht die Erklärung für diesen zweiten Fehler.

## Ursache der fehlenden Diagnose

Im `Development`-Zweig von `ConfigureMiddleware` (den `TestWebApplicationFactory` über `UseEnvironment("Development")` verwendet) war **keine** Exception-Handling-Middleware aktiv. Ein unbehandelter Fehler liefert daher nur einen leeren `500`-Body ohne jeglichen Stacktrace — weder lokal noch in den CI-Logs war die eigentliche Ursache sichtbar.

## Änderungen

- `UseDeveloperExceptionPage()` im `Development`-Zweig aktiviert (Produktion nutzt weiterhin unverändert `UseExceptionHandler` im `else`-Zweig für `!IsDevelopment()`).
- `AuthenticateAdminAsync` in `UpdateControllerIntegrationTests` liest bei einem Fehlschlag den Response-Body statt nur `EnsureSuccessStatusCode()` aufzurufen.

Damit zeigt der nächste CI-Fehlschlag den echten Stacktrace, statt nur "500 Internal Server Error".

## Test plan

- [x] `dotnet build` der gesamten Solution ohne Fehler
- [x] `FinanceManager.Tests.Integration` (Release) 5x hintereinander grün
- [x] `FinanceManager.Tests` vollständig grün (888/888)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>