### PR TITLE
Missing Translation for Statement Draft Validation Results

### DIFF
--- a/FinanceManager.Infrastructure/Statements/BudgetImpactEvaluationService.cs
+++ b/FinanceManager.Infrastructure/Statements/BudgetImpactEvaluationService.cs
@@ -328,10 +328,10 @@ public sealed class BudgetImpactEvaluationService : IBudgetImpactEvaluationServi
     {
         return hintType switch
         {
-            BudgetImpactHintType.Exceeded => $"Budget überschritten (Soll: {target.ToString("0.##", CultureInfo.InvariantCulture)}, Ist nachher: {actualAfter.ToString("0.##", CultureInfo.InvariantCulture)}).",
-            BudgetImpactHintType.AlmostExhausted => $"Budget fast ausgeschöpft (Soll: {target.ToString("0.##", CultureInfo.InvariantCulture)}, Ist nachher: {actualAfter.ToString("0.##", CultureInfo.InvariantCulture)}).",
-            BudgetImpactHintType.StronglyChanged => $"Zielerreichung stark verändert (Δ Quote: {(delta * 100m).ToString("0.##", CultureInfo.InvariantCulture)}%).",
-            _ => $"Keine kritische Abweichung (Ist vorher: {actualBefore.ToString("0.##", CultureInfo.InvariantCulture)}, Ist nachher: {actualAfter.ToString("0.##", CultureInfo.InvariantCulture)})."
+            BudgetImpactHintType.Exceeded => $"Budget_BudgetExceeded|{target.ToString("0.##", CultureInfo.InvariantCulture)}|{actualAfter.ToString("0.##", CultureInfo.InvariantCulture)}",
+            BudgetImpactHintType.AlmostExhausted => $"Budget_BudgetAlmostExhausted|{target.ToString("0.##", CultureInfo.InvariantCulture)}|{actualAfter.ToString("0.##", CultureInfo.InvariantCulture)}",
+            BudgetImpactHintType.StronglyChanged => $"Budget_StronglyChanged|{(delta * 100m).ToString("0.##", CultureInfo.InvariantCulture)}",
+            _ => $"Budget_NoCriticalDeviation|{actualBefore.ToString("0.##", CultureInfo.InvariantCulture)}|{actualAfter.ToString("0.##", CultureInfo.InvariantCulture)}"
         };
     }
 

--- a/FinanceManager.Infrastructure/Statements/StatementDraftService.cs
+++ b/FinanceManager.Infrastructure/Statements/StatementDraftService.cs
@@ -1643,11 +1643,11 @@ public sealed partial class StatementDraftService : IStatementDraftService
 
         var entries = await scopedEntryQuery.ToArrayAsync(ct);
 
-        void Add(string code, string sev, string msg, Guid? draftId, Guid? eId) => messages.Add(new DraftValidationMessageDto(code, sev, msg, draftId ?? draft.Id, eId));
+        void Add(string code, string sev, string msg, Guid? draftId, Guid? eId, string prefix = "") => messages.Add(new DraftValidationMessageDto(code, sev, prefix + msg, draftId ?? draft.Id, eId));
 
         if (draft.DetectedAccountId == null)
         {
-            Add("NO_ACCOUNT", "Error", "Kein Konto zugeordnet.", null, null);
+            Add("NO_ACCOUNT", "Error", "Validation_NO_ACCOUNT", null, null);
         }
 
         var self = await _db.Contacts.AsNoTracking().FirstOrDefaultAsync(c => c.OwnerUserId == ownerUserId && c.Type == ContactType.Self, ct);
@@ -1676,7 +1676,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
         }
         if (DetectCycle(draft.Id))
         {
-            Add("SPLIT_CYCLE_DETECTED", "Error", "[Split] Zyklen in Split-Verknüpfungen erkannt.", null, null);
+            Add("SPLIT_CYCLE_DETECTED", "Error", "Validation_SPLIT_CYCLE_DETECTED", null, null);
         }
 
         async Task<List<StatementDraft>> LoadSplitGroupAsync(StatementDraft rootChild, StatementDraft parent, Guid userId, CancellationToken token)
@@ -1707,18 +1707,18 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 .ToList();
             if (groupDrafts.Any(d => d.DetectedAccountId != null))
             {
-                Add("SPLIT_DRAFT_HAS_ACCOUNT", "Error", prefix + "Split-Draft darf kein Konto zugeordnet haben.", draft.Id, parentEntry.Id);
+                Add("SPLIT_DRAFT_HAS_ACCOUNT", "Error", "Validation_SPLIT_DRAFT_HAS_ACCOUNT", draft.Id, parentEntry.Id, prefix);
             }
             var sum = groupEntries.Sum(e => e.Amount);
             if (sum != parentEntry.Amount)
             {
-                Add("SPLIT_AMOUNT_MISMATCH", "Error", prefix + "Summe der Aufteilung entspricht nicht dem Ursprungsbetrag.", draft.Id, parentEntry.Id);
+                Add("SPLIT_AMOUNT_MISMATCH", "Error", "Validation_SPLIT_AMOUNT_MISMATCH", draft.Id, parentEntry.Id, prefix);
             }
             foreach (var ce in groupEntries)
             {
                 if (ce.ContactId == null)
                 {
-                    Add("ENTRY_NO_CONTACT", "Error", prefix + "Kein Kontakt zugeordnet.", parentEntry.DraftId, parentEntry.Id);
+                    Add("ENTRY_NO_CONTACT", "Error", "Validation_ENTRY_NO_CONTACT", parentEntry.DraftId, parentEntry.Id, prefix);
                     continue;
                 }
                 var c = await _db.Contacts.AsNoTracking().FirstOrDefaultAsync(x => x.Id == ce.ContactId && x.OwnerUserId == ownerUserId, token);
@@ -1727,7 +1727,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 {
                     if (ce.SplitDraftId == null)
                     {
-                        Add("INTERMEDIARY_NO_SPLIT", "Error", prefix + "Zahlungsdienst ohne weitere Aufteilung.", parentEntry.DraftId, parentEntry.Id);
+                        Add("INTERMEDIARY_NO_SPLIT", "Error", "Validation_INTERMEDIARY_NO_SPLIT", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                     else
                     {
@@ -1739,7 +1739,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
                     // Determine severity based on parent account setting; default to Warning when account unknown
                     if (account == null)
                     {
-                        Add("SAVINGSPLAN_MISSING_FOR_SELF", "Warning", prefix + "Für Eigentransfer ist ein Sparplan sinnvoll.", parentEntry.DraftId, parentEntry.Id);
+                        Add("SAVINGSPLAN_MISSING_FOR_SELF", "Warning", "Validation_SAVINGSPLAN_MISSING_FOR_SELF", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                     else
                     {
@@ -1752,7 +1752,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
                         };
                         if (sev != null)
                         {
-                            Add("SAVINGSPLAN_MISSING_FOR_SELF", sev, prefix + "Für Eigentransfer ist ein Sparplan sinnvoll.", parentEntry.DraftId, parentEntry.Id);
+                            Add("SAVINGSPLAN_MISSING_FOR_SELF", sev, "Validation_SAVINGSPLAN_MISSING_FOR_SELF", parentEntry.DraftId, parentEntry.Id, prefix);
                         }
                     }
                 }
@@ -1765,32 +1765,32 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 {
                     if (!account.SecurityProcessingEnabled)
                     {
-                        Add("SECURITY_ACCOUNT_NOT_ALLOWED", "Error", prefix + "Wertpapierabwicklung ist für dieses Konto deaktiviert.", parentEntry.DraftId, parentEntry.Id);
+                        Add("SECURITY_ACCOUNT_NOT_ALLOWED", "Error", "Validation_SECURITY_ACCOUNT_NOT_ALLOWED", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                     if (ce.ContactId != account.BankContactId)
                     {
-                        Add("SECURITY_INVALID_CONTACT", "Error", prefix + "Wertpapierbuchung erfordert Bankkontakt des Kontos.", parentEntry.DraftId, parentEntry.Id);
+                        Add("SECURITY_INVALID_CONTACT", "Error", "Validation_SECURITY_INVALID_CONTACT", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                     if (ce.SecurityTransactionType == null)
                     {
-                        Add("SECURITY_MISSING_TXTYPE", "Error", prefix + "Wertpapier: Transaktionstyp fehlt.", parentEntry.DraftId, parentEntry.Id);
+                        Add("SECURITY_MISSING_TXTYPE", "Error", "Validation_SECURITY_MISSING_TXTYPE", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                     if (ce.SecurityTransactionType != null && ce.SecurityTransactionType != SecurityTransactionType.Dividend)
                     {
                         if (ce.SecurityQuantity == null || ce.SecurityQuantity <= 0m)
                         {
-                            Add("SECURITY_MISSING_QUANTITY", "Error", prefix + "Wertpapier: Stückzahl fehlt.", parentEntry.DraftId, parentEntry.Id);
+                            Add("SECURITY_MISSING_QUANTITY", "Error", "Validation_SECURITY_MISSING_QUANTITY", parentEntry.DraftId, parentEntry.Id, prefix);
                         }
                     }
                     if (ce.SecurityTransactionType == SecurityTransactionType.Dividend && ce.SecurityQuantity != null)
                     {
-                        Add("SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND", "Error", prefix + "Wertpapier: Menge ist bei Dividende nicht zulässig.", parentEntry.DraftId, parentEntry.Id);
+                        Add("SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND", "Error", "Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                     var fee = ce.SecurityFeeAmount ?? 0m;
                     var tax = ce.SecurityTaxAmount ?? 0m;
                     if (fee + tax > Math.Abs(ce.Amount))
                     {
-                        Add("SECURITY_FEE_TAX_EXCEEDS_AMOUNT", "Error", prefix + "Wertpapier: Gebühren+Steuern übersteigen Betrag.", parentEntry.DraftId, parentEntry.Id);
+                        Add("SECURITY_FEE_TAX_EXCEEDS_AMOUNT", "Error", "Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT", parentEntry.DraftId, parentEntry.Id, prefix);
                     }
                 }
             }
@@ -1803,12 +1803,12 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 if (entryId != null && e.Id != entryId) { continue; }
                 if (e.ContactId == null)
                 {
-                    Add("ENTRY_NO_CONTACT", "Error", "Kein Kontakt zugeordnet.", null, e.Id);
+                    Add("ENTRY_NO_CONTACT", "Error", "Validation_ENTRY_NO_CONTACT", null, e.Id);
                     continue;
                 }
                 if (e.Status == StatementDraftEntryStatus.Open)
                 {
-                    Add("ENTRY_NEEDS_CHECK", "Error", "Eine Prüfung der Angaben ist erforderlich.", null, e.Id);
+                    Add("ENTRY_NEEDS_CHECK", "Error", "Validation_ENTRY_NEEDS_CHECK", null, e.Id);
                     continue;
                 }
                 var c = await _db.Contacts.AsNoTracking().FirstOrDefaultAsync(x => x.Id == e.ContactId && x.OwnerUserId == ownerUserId, ct);
@@ -1817,7 +1817,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 {
                     if (e.SplitDraftId == null)
                     {
-                        Add("INTERMEDIARY_NO_SPLIT", "Error", "Zahlungsdienst ohne Aufteilungs-Entwurf.", null, e.Id);
+                        Add("INTERMEDIARY_NO_SPLIT", "Error", "Validation_INTERMEDIARY_NO_SPLIT", null, e.Id);
                     }
                     else
                     {
@@ -1831,7 +1831,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
                         // Use account setting to decide severity; default to Warning
                         if (account == null)
                         {
-                            Add("SAVINGSPLAN_MISSING_FOR_SELF", "Warning", "Für Eigentransfer ist ein Sparplan sinnvoll.", null, e.Id);
+                            Add("SAVINGSPLAN_MISSING_FOR_SELF", "Warning", "Validation_SAVINGSPLAN_MISSING_FOR_SELF", null, e.Id);
                         }
                         else
                         {
@@ -1844,13 +1844,13 @@ public sealed partial class StatementDraftService : IStatementDraftService
                             };
                             if (sev != null)
                             {
-                                Add("SAVINGSPLAN_MISSING_FOR_SELF", sev, "Für Eigentransfer ist ein Sparplan sinnvoll.", null, e.Id);
+                                Add("SAVINGSPLAN_MISSING_FOR_SELF", sev, "Validation_SAVINGSPLAN_MISSING_FOR_SELF", null, e.Id);
                             }
                         }
                     }
                     else if (account != null && account.Type == AccountType.Savings)
                     {
-                        Add("SAVINGSPLAN_INVALID_ACCOUNT", "Error", "Sparplan auf Sparkonto ist nicht zulässig.", null, e.Id);
+                        Add("SAVINGSPLAN_INVALID_ACCOUNT", "Error", "Validation_SAVINGSPLAN_INVALID_ACCOUNT", null, e.Id);
                     }
                 }
                 var hasSecurity = e.SecurityId != null
@@ -1862,32 +1862,32 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 {
                     if (!account.SecurityProcessingEnabled)
                     {
-                        Add("SECURITY_ACCOUNT_NOT_ALLOWED", "Error", "Wertpapierabwicklung ist für dieses Konto deaktiviert.", null, e.Id);
+                        Add("SECURITY_ACCOUNT_NOT_ALLOWED", "Error", "Validation_SECURITY_ACCOUNT_NOT_ALLOWED", null, e.Id);
                     }
                     if (e.ContactId != account.BankContactId)
                     {
-                        Add("SECURITY_INVALID_CONTACT", "Error", "Wertpapierbuchung erfordert Bankkontakt des Kontos.", null, e.Id);
+                        Add("SECURITY_INVALID_CONTACT", "Error", "Validation_SECURITY_INVALID_CONTACT", null, e.Id);
                     }
                     if (e.SecurityTransactionType == null)
                     {
-                        Add("SECURITY_MISSING_TXTYPE", "Error", "Wertpapier: Transaktionstyp fehlt.", null, e.Id);
+                        Add("SECURITY_MISSING_TXTYPE", "Error", "Validation_SECURITY_MISSING_TXTYPE", null, e.Id);
                     }
                     if (e.SecurityTransactionType != null && e.SecurityTransactionType != SecurityTransactionType.Dividend)
                     {
                         if (e.SecurityQuantity == null || e.SecurityQuantity <= 0m)
                         {
-                            Add("SECURITY_MISSING_QUANTITY", "Error", "Wertpapier: Stückzahl fehlt.", null, e.Id);
+                            Add("SECURITY_MISSING_QUANTITY", "Error", "Validation_SECURITY_MISSING_QUANTITY", null, e.Id);
                         }
                     }
                     if (e.SecurityTransactionType == SecurityTransactionType.Dividend && e.SecurityQuantity != null)
                     {
-                        Add("SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND", "Error", "Wertpapier: Menge ist bei Dividende nicht zulässig.", null, e.Id);
+                        Add("SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND", "Error", "Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND", null, e.Id);
                     }
                     var fee = e.SecurityFeeAmount ?? 0m;
                     var tax = e.SecurityTaxAmount ?? 0m;
                     if (fee + tax > Math.Abs(e.Amount))
                     {
-                        Add("SECURITY_FEE_TAX_EXCEEDS_AMOUNT", "Error", "Wertpapier: Gebühren+Steuern übersteigen Betrag.", null, e.Id);
+                        Add("SECURITY_FEE_TAX_EXCEEDS_AMOUNT", "Error", "Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT", null, e.Id);
                     }
                 }
             }
@@ -1921,15 +1921,15 @@ public sealed partial class StatementDraftService : IStatementDraftService
                 var remaining = target - current;
                 if (remaining > 0m && planned == remaining)
                 {
-                    messages.Add(new("SAVINGSPLAN_GOAL_REACHED_INFO", "Information", $"Mit den Buchungen in diesem Auszug wird das Sparziel des Sparplans '{plan.Name}' erreicht.", draft.Id, null, "savings-plans", plan.Id));
+                    messages.Add(new("SAVINGSPLAN_GOAL_REACHED_INFO", "Information", $"Validation_SAVINGSPLAN_GOAL_REACHED_INFO|{plan.Name}", draft.Id, null, "savings-plans", plan.Id));
                 }
                 else if (remaining > 0m && planned > remaining)
                 {
-                    messages.Add(new("SAVINGSPLAN_GOAL_EXCEEDS", "Warning", $"Die geplanten Buchungen überschreiten das Sparziel des Sparplans '{plan.Name}'.", draft.Id, null, "savings-plans", plan.Id));
+                    messages.Add(new("SAVINGSPLAN_GOAL_EXCEEDS", "Warning", $"Validation_SAVINGSPLAN_GOAL_EXCEEDS|{plan.Name}", draft.Id, null, "savings-plans", plan.Id));
                 }
                 if (wantsArchive && current + planned != target)
                 {
-                    messages.Add(new("SAVINGSPLAN_ARCHIVE_MISMATCH", "Error", $"Sparplan '{plan.Name}' kann nicht archiviert werden: Buchungen gleichen den Restbetrag nicht exakt aus.", draft.Id, null, "savings-plans", plan.Id));
+                    messages.Add(new("SAVINGSPLAN_ARCHIVE_MISMATCH", "Error", $"Validation_SAVINGSPLAN_ARCHIVE_MISMATCH|{plan.Name}", draft.Id, null, "savings-plans", plan.Id));
                 }
             }
         }
@@ -1963,7 +1963,7 @@ public sealed partial class StatementDraftService : IStatementDraftService
                     .Join(_db.StatementDrafts, e => e.DraftId, d => d.Id, (e, d) => new { e, d })
                     .AnyAsync(x => x.d.OwnerUserId == ownerUserId && x.d.Status == StatementDraftStatus.Draft && x.e.SavingsPlanId == plan.Id, ct);
                 if (assignedInOpenDraft) { continue; }
-                messages.Add(new("SAVINGSPLAN_DUE", "Information", $"Sparplan '{plan.Name}' ist fällig (Fälligkeitsdatum: {effectiveDue:d}).", draft.Id, null, "savings-plans", plan.Id));
+                messages.Add(new("SAVINGSPLAN_DUE", "Information", $"Validation_SAVINGSPLAN_DUE|{plan.Name}|{effectiveDue:d}", draft.Id, null, "savings-plans", plan.Id));
             }
         }
         var isValid = messages.All(m => !string.Equals(m.Severity, "Error", StringComparison.OrdinalIgnoreCase));

--- a/FinanceManager.Tests/Components/ValidationResultPanelTests.cs
+++ b/FinanceManager.Tests/Components/ValidationResultPanelTests.cs
@@ -19,7 +19,7 @@ public sealed class ValidationResultPanelTests : BunitContext
     {
         // Arrange
         Services.AddLocalization(options => options.ResourcesPath = "Resources");
-        Services.AddSingleton(typeof(IStringLocalizer<Pages>), new PagesStringLocalizer());
+        Services.AddSingleton(typeof(IStringLocalizer<FinanceManager.Web.Pages>), new PagesStringLocalizer());
 
         var draftId = Guid.NewGuid();
         var relatedId = Guid.NewGuid();
@@ -31,7 +31,7 @@ public sealed class ValidationResultPanelTests : BunitContext
             true,
             new List<DraftValidationMessageDto>
             {
-                new("SAVINGSPLAN_DUE", "Information", "Sparplan ist faellig.", draftId, null, "savings-plans", relatedId)
+                new("SAVINGSPLAN_DUE", "Information", "Validation_SAVINGSPLAN_DUE|Test Plan|05/01/2025", draftId, null, "savings-plans", relatedId)
             });
 
         // Act
@@ -59,7 +59,7 @@ public sealed class ValidationResultPanelTests : BunitContext
     {
         // Arrange
         Services.AddLocalization(options => options.ResourcesPath = "Resources");
-        Services.AddSingleton(typeof(IStringLocalizer<Pages>), new PagesStringLocalizer());
+        Services.AddSingleton(typeof(IStringLocalizer<FinanceManager.Web.Pages>), new PagesStringLocalizer());
 
         var draftId = Guid.NewGuid();
         var entryId = Guid.NewGuid();
@@ -69,7 +69,7 @@ public sealed class ValidationResultPanelTests : BunitContext
             false,
             new List<DraftValidationMessageDto>
             {
-                new("ENTRY_HINT", "Information", "Entry-specific hint.", draftId, entryId, "savings-plans", relatedId)
+                new("ENTRY_HINT", "Information", "Validation_ENTRY_NO_CONTACT", draftId, entryId, "savings-plans", relatedId)
             });
 
         // Act

--- a/FinanceManager.Web/Components/Shared/ValidationResultPanel.razor
+++ b/FinanceManager.Web/Components/Shared/ValidationResultPanel.razor
@@ -24,7 +24,7 @@ else
             @foreach (var m in ValidationResult.Messages.Where(e => e.EntryId is null))
             {
                 <li style="margin:.25rem 0;">
-                    @($"[{m.Severity}] {m.Message}")
+                    @($"[{m.Severity}] {GetLocalizedMessage(m)}")
                     @{
                         var relatedRecordUrl = BuildRelatedRecordUrl(m);
                     }
@@ -91,5 +91,59 @@ else
         var currentPath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         var currentUrl = "/" + currentPath;
         return $"/card/{kind}/{message.RelatedRecordId}?back={Uri.EscapeDataString(currentUrl)}";
+    }
+
+    private string GetLocalizedMessage(DraftValidationMessageDto message)
+    {
+        // Check if the message contains a translation key with parameters (format: Key|param1|param2)
+        if (message.Message.Contains('|'))
+        {
+            var parts = message.Message.Split('|');
+            var key = parts[0];
+            var parameters = parts.Skip(1).ToArray();
+            
+            // Try to get the localized string
+            var localizedString = Localizer?[key];
+            if (localizedString != null && !localizedString.ResourceNotFound)
+            {
+                // Format the message with parameters
+                try
+                {
+                    // Convert parameters to appropriate types for formatting
+                    var formattedParams = new List<object>();
+                    foreach (var p in parameters)
+                    {
+                        // Try to parse as DateTime for date formatting
+                        if (DateTime.TryParse(p, out var dateValue))
+                        {
+                            formattedParams.Add(dateValue);
+                        }
+                        else
+                        {
+                            formattedParams.Add(p);
+                        }
+                    }
+                    
+                    return string.Format(localizedString, formattedParams.ToArray());
+                }
+                catch (FormatException)
+                {
+                    // If formatting fails, return the key as fallback
+                    return message.Message;
+                }
+            }
+        }
+        else
+        {
+            // Simple translation key without parameters
+            var localizedString = Localizer?[message.Message];
+            if (localizedString != null && !localizedString.ResourceNotFound)
+            {
+                return localizedString;
+            }
+        }
+        
+        // Fallback to the original message if translation not found
+        return message.Message;
     }
 }

--- a/FinanceManager.Web/Components/Statements/BudgetImpactSummaryPanel.razor
+++ b/FinanceManager.Web/Components/Statements/BudgetImpactSummaryPanel.razor
@@ -1,4 +1,6 @@
 @using FinanceManager.Shared.Dtos.Statements
+@using System.Linq
+@using System.Collections.Generic
 @inject Microsoft.Extensions.Localization.IStringLocalizer<FinanceManager.Web.Pages> Localizer
 
 @if (BudgetImpact == null || BudgetImpact.Items == null || BudgetImpact.Items.Count == 0)
@@ -40,7 +42,7 @@ else
                         </div>
                         @if (!string.IsNullOrWhiteSpace(hint.Reason))
                         {
-                            <div style="margin-top:.25rem;font-size:.9rem;opacity:.85;">@hint.Reason</div>
+                            <div style="margin-top:.25rem;font-size:.9rem;opacity:.85;">@GetLocalizedMessage(hint.Reason)</div>
                         }
                     </div>
                 </div>
@@ -51,4 +53,45 @@ else
 
 @code {
     [Parameter] public BookingImpactSummaryDto? BudgetImpact { get; set; }
+
+    private string GetLocalizedMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return message;
+        }
+
+        // Check if the message contains a pipe separator (indicating translation key with parameters)
+        if (message.Contains('|'))
+        {
+            var parts = message.Split('|');
+            var key = parts[0];
+            var parameters = parts.Skip(1).ToArray();
+
+            // Try to get the localized string
+            var localizedString = Localizer?[key];
+            if (localizedString != null && !localizedString.ResourceNotFound)
+            {
+                // Format the message with parameters
+                try
+                {
+                    var formattedParams = new List<object>();
+                    foreach (var p in parameters)
+                    {
+                        formattedParams.Add(p);
+                    }
+                    
+                    return string.Format(localizedString, formattedParams.ToArray());
+                }
+                catch (FormatException)
+                {
+                    // If formatting fails, return the key as fallback
+                    return message;
+                }
+            }
+        }
+        
+        // If no translation key format or translation not found, return the original message
+        return message;
+    }
 }

--- a/FinanceManager.Web/Components/Statements/BudgetImpactValidationPanel.razor
+++ b/FinanceManager.Web/Components/Statements/BudgetImpactValidationPanel.razor
@@ -1,4 +1,6 @@
 @using FinanceManager.Shared.Dtos.Statements
+@using System.Linq
+@using System.Collections.Generic
 @inject Microsoft.Extensions.Localization.IStringLocalizer<FinanceManager.Web.Pages> Localizer
 
 @if (ValidationResult?.BudgetImpact == null || ValidationResult.BudgetImpact.Items == null || ValidationResult.BudgetImpact.Items.Count == 0)
@@ -40,7 +42,7 @@ else
                         </div>
                         @if (!string.IsNullOrWhiteSpace(hint.Reason))
                         {
-                            <div style="margin-top:.25rem;font-size:.9rem;opacity:.85;">@hint.Reason</div>
+                            <div style="margin-top:.25rem;font-size:.9rem;opacity:.85;">@GetLocalizedMessage(hint.Reason)</div>
                         }
                     </div>
                 </div>
@@ -51,4 +53,45 @@ else
 
 @code {
     [Parameter] public DraftValidationResultDto? ValidationResult { get; set; }
+
+    private string GetLocalizedMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return message;
+        }
+
+        // Check if the message contains a pipe separator (indicating translation key with parameters)
+        if (message.Contains('|'))
+        {
+            var parts = message.Split('|');
+            var key = parts[0];
+            var parameters = parts.Skip(1).ToArray();
+
+            // Try to get the localized string
+            var localizedString = Localizer?[key];
+            if (localizedString != null && !localizedString.ResourceNotFound)
+            {
+                // Format the message with parameters
+                try
+                {
+                    var formattedParams = new List<object>();
+                    foreach (var p in parameters)
+                    {
+                        formattedParams.Add(p);
+                    }
+                    
+                    return string.Format(localizedString, formattedParams.ToArray());
+                }
+                catch (FormatException)
+                {
+                    // If formatting fails, return the key as fallback
+                    return message;
+                }
+            }
+        }
+        
+        // If no translation key format or translation not found, return the original message
+        return message;
+    }
 }

--- a/FinanceManager.Web/Resources/Components/Pages/StatementDraftDetail.de.resx
+++ b/FinanceManager.Web/Resources/Components/Pages/StatementDraftDetail.de.resx
@@ -333,4 +333,61 @@
   <data name="NoMatches" xml:space="preserve">
     <value>Keine Treffer</value>
   </data>
+  <data name="Validation_NO_ACCOUNT" xml:space="preserve">
+    <value>Kein Konto zugeordnet.</value>
+  </data>
+  <data name="Validation_SPLIT_CYCLE_DETECTED" xml:space="preserve">
+    <value>[Split] Zyklen in Split-Verknüpfungen erkannt.</value>
+  </data>
+  <data name="Validation_SPLIT_DRAFT_HAS_ACCOUNT" xml:space="preserve">
+    <value>Split-Draft darf kein Konto zugeordnet haben.</value>
+  </data>
+  <data name="Validation_SPLIT_AMOUNT_MISMATCH" xml:space="preserve">
+    <value>Summe der Aufteilung entspricht nicht dem Ursprungsbetrag.</value>
+  </data>
+  <data name="Validation_ENTRY_NO_CONTACT" xml:space="preserve">
+    <value>Kein Kontakt zugeordnet.</value>
+  </data>
+  <data name="Validation_INTERMEDIARY_NO_SPLIT" xml:space="preserve">
+    <value>Zahlungsdienst ohne weitere Aufteilung.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_MISSING_FOR_SELF" xml:space="preserve">
+    <value>Für Eigentransfer ist ein Sparplan sinnvoll.</value>
+  </data>
+  <data name="Validation_SECURITY_ACCOUNT_NOT_ALLOWED" xml:space="preserve">
+    <value>Wertpapierabwicklung ist für dieses Konto deaktiviert.</value>
+  </data>
+  <data name="Validation_SECURITY_INVALID_CONTACT" xml:space="preserve">
+    <value>Wertpapierbuchung erfordert Bankkontakt des Kontos.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_TXTYPE" xml:space="preserve">
+    <value>Wertpapier: Transaktionstyp fehlt.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_QUANTITY" xml:space="preserve">
+    <value>Wertpapier: Stückzahl fehlt.</value>
+  </data>
+  <data name="Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND" xml:space="preserve">
+    <value>Wertpapier: Menge ist bei Dividende nicht zulässig.</value>
+  </data>
+  <data name="Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT" xml:space="preserve">
+    <value>Wertpapier: Gebühren+Steuern übersteigen Betrag.</value>
+  </data>
+  <data name="Validation_ENTRY_NEEDS_CHECK" xml:space="preserve">
+    <value>Eine Prüfung der Angaben ist erforderlich.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Sparplan auf Sparkonto ist nicht zulässig.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_REACHED_INFO" xml:space="preserve">
+    <value>Mit den Buchungen in diesem Auszug wird das Sparziel des Sparplans '{0}' erreicht.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_EXCEEDS" xml:space="preserve">
+    <value>Die geplanten Buchungen überschreiten das Sparziel des Sparplans '{0}'.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_ARCHIVE_MISMATCH" xml:space="preserve">
+    <value>Sparplan '{0}' kann nicht archiviert werden: Buchungen gleichen den Restbetrag nicht exakt aus.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_DUE" xml:space="preserve">
+    <value>Sparplan '{0}' ist fällig (Fälligkeitsdatum: {1:d}).</value>
+  </data>
 </root>

--- a/FinanceManager.Web/Resources/Components/Pages/StatementDraftDetail.en.resx
+++ b/FinanceManager.Web/Resources/Components/Pages/StatementDraftDetail.en.resx
@@ -312,4 +312,61 @@
   <data name="Ribbon_Group_Operations" xml:space="preserve">
     <value>Operations</value>
   </data>
+  <data name="Validation_NO_ACCOUNT" xml:space="preserve">
+    <value>No account assigned.</value>
+  </data>
+  <data name="Validation_SPLIT_CYCLE_DETECTED" xml:space="preserve">
+    <value>[Split] Cycles detected in split connections.</value>
+  </data>
+  <data name="Validation_SPLIT_DRAFT_HAS_ACCOUNT" xml:space="preserve">
+    <value>Split draft must not have an account assigned.</value>
+  </data>
+  <data name="Validation_SPLIT_AMOUNT_MISMATCH" xml:space="preserve">
+    <value>Sum of split does not match original amount.</value>
+  </data>
+  <data name="Validation_ENTRY_NO_CONTACT" xml:space="preserve">
+    <value>No contact assigned.</value>
+  </data>
+  <data name="Validation_INTERMEDIARY_NO_SPLIT" xml:space="preserve">
+    <value>Payment service without further split.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_MISSING_FOR_SELF" xml:space="preserve">
+    <value>For self-transfer, a savings plan is recommended.</value>
+  </data>
+  <data name="Validation_SECURITY_ACCOUNT_NOT_ALLOWED" xml:space="preserve">
+    <value>Security processing is disabled for this account.</value>
+  </data>
+  <data name="Validation_SECURITY_INVALID_CONTACT" xml:space="preserve">
+    <value>Security booking requires bank contact of the account.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_TXTYPE" xml:space="preserve">
+    <value>Security: Transaction type missing.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_QUANTITY" xml:space="preserve">
+    <value>Security: Quantity missing.</value>
+  </data>
+  <data name="Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND" xml:space="preserve">
+    <value>Security: Quantity not allowed for dividend.</value>
+  </data>
+  <data name="Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT" xml:space="preserve">
+    <value>Security: Fees+taxes exceed amount.</value>
+  </data>
+  <data name="Validation_ENTRY_NEEDS_CHECK" xml:space="preserve">
+    <value>A check of the information is required.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Savings plan on savings account is not allowed.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_REACHED_INFO" xml:space="preserve">
+    <value>With the bookings in this statement, the savings goal of the savings plan '{0}' will be reached.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_EXCEEDS" xml:space="preserve">
+    <value>The planned bookings exceed the savings goal of the savings plan '{0}'.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_ARCHIVE_MISMATCH" xml:space="preserve">
+    <value>Savings plan '{0}' cannot be archived: Bookings do not exactly match the remaining amount.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_DUE" xml:space="preserve">
+    <value>Savings plan '{0}' is due (Due date: {1:d}).</value>
+  </data>
 </root>

--- a/FinanceManager.Web/Resources/Pages.de.resx
+++ b/FinanceManager.Web/Resources/Pages.de.resx
@@ -2336,4 +2336,74 @@
   </data>
   <data name="SetupUpdate_Th_Sha256" xml:space="preserve">
     <value>SHA-256</value>
-  </data></root>
+  </data>
+  <data name="Validation_NO_ACCOUNT" xml:space="preserve">
+    <value>Kein Konto zugeordnet.</value>
+  </data>
+  <data name="Validation_SPLIT_CYCLE_DETECTED" xml:space="preserve">
+    <value>[Split] Zyklen in Split-Verknüpfungen erkannt.</value>
+  </data>
+  <data name="Validation_SPLIT_DRAFT_HAS_ACCOUNT" xml:space="preserve">
+    <value>Split-Draft darf kein Konto zugeordnet haben.</value>
+  </data>
+  <data name="Validation_SPLIT_AMOUNT_MISMATCH" xml:space="preserve">
+    <value>Summe der Aufteilung entspricht nicht dem Ursprungsbetrag.</value>
+  </data>
+  <data name="Validation_ENTRY_NO_CONTACT" xml:space="preserve">
+    <value>Kein Kontakt zugeordnet.</value>
+  </data>
+  <data name="Validation_INTERMEDIARY_NO_SPLIT" xml:space="preserve">
+    <value>Zahlungsdienst ohne weitere Aufteilung.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_MISSING_FOR_SELF" xml:space="preserve">
+    <value>Für Eigentransfer ist ein Sparplan sinnvoll.</value>
+  </data>
+  <data name="Validation_SECURITY_ACCOUNT_NOT_ALLOWED" xml:space="preserve">
+    <value>Wertpapierabwicklung ist für dieses Konto deaktiviert.</value>
+  </data>
+  <data name="Validation_SECURITY_INVALID_CONTACT" xml:space="preserve">
+    <value>Wertpapierbuchung erfordert Bankkontakt des Kontos.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_TXTYPE" xml:space="preserve">
+    <value>Wertpapier: Transaktionstyp fehlt.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_QUANTITY" xml:space="preserve">
+    <value>Wertpapier: Stückzahl fehlt.</value>
+  </data>
+  <data name="Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND" xml:space="preserve">
+    <value>Wertpapier: Menge ist bei Dividende nicht zulässig.</value>
+  </data>
+  <data name="Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT" xml:space="preserve">
+    <value>Wertpapier: Gebühren+Steuern übersteigen Betrag.</value>
+  </data>
+  <data name="Validation_ENTRY_NEEDS_CHECK" xml:space="preserve">
+    <value>Eine Prüfung der Angaben ist erforderlich.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Sparplan auf Sparkonto ist nicht zulässig.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_REACHED_INFO" xml:space="preserve">
+    <value>Mit den Buchungen in diesem Auszug wird das Sparziel des Sparplans '{0}' erreicht.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_EXCEEDS" xml:space="preserve">
+    <value>Die geplanten Buchungen überschreiten das Sparziel des Sparplans '{0}'.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_ARCHIVE_MISMATCH" xml:space="preserve">
+    <value>Sparplan '{0}' kann nicht archiviert werden: Buchungen gleichen den Restbetrag nicht exakt aus.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_DUE" xml:space="preserve">
+    <value>Sparplan '{0}' ist fällig (Fälligkeitsdatum: {1:d}).</value>
+  </data>
+  <data name="Budget_BudgetExceeded" xml:space="preserve">
+    <value>Budget überschritten (Soll: {0}, Ist nachher: {1}).</value>
+  </data>
+  <data name="Budget_BudgetAlmostExhausted" xml:space="preserve">
+    <value>Budget fast ausgeschöpft (Soll: {0}, Ist nachher: {1}).</value>
+  </data>
+  <data name="Budget_StronglyChanged" xml:space="preserve">
+    <value>Zielerreichung stark verändert (Δ Quote: {0}%).</value>
+  </data>
+  <data name="Budget_NoCriticalDeviation" xml:space="preserve">
+    <value>Keine kritische Abweichung (Ist vorher: {0}, Ist nachher: {1}).</value>
+  </data>
+</root>

--- a/FinanceManager.Web/Resources/Pages.en.resx
+++ b/FinanceManager.Web/Resources/Pages.en.resx
@@ -2336,4 +2336,74 @@
   </data>
   <data name="SetupUpdate_Th_Sha256" xml:space="preserve">
     <value>SHA-256</value>
-  </data></root>
+  </data>
+  <data name="Validation_NO_ACCOUNT" xml:space="preserve">
+    <value>No account assigned.</value>
+  </data>
+  <data name="Validation_SPLIT_CYCLE_DETECTED" xml:space="preserve">
+    <value>[Split] Cycles detected in split connections.</value>
+  </data>
+  <data name="Validation_SPLIT_DRAFT_HAS_ACCOUNT" xml:space="preserve">
+    <value>Split draft must not have an account assigned.</value>
+  </data>
+  <data name="Validation_SPLIT_AMOUNT_MISMATCH" xml:space="preserve">
+    <value>Sum of split does not match original amount.</value>
+  </data>
+  <data name="Validation_ENTRY_NO_CONTACT" xml:space="preserve">
+    <value>No contact assigned.</value>
+  </data>
+  <data name="Validation_INTERMEDIARY_NO_SPLIT" xml:space="preserve">
+    <value>Payment service without further split.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_MISSING_FOR_SELF" xml:space="preserve">
+    <value>For self-transfer, a savings plan is recommended.</value>
+  </data>
+  <data name="Validation_SECURITY_ACCOUNT_NOT_ALLOWED" xml:space="preserve">
+    <value>Security processing is disabled for this account.</value>
+  </data>
+  <data name="Validation_SECURITY_INVALID_CONTACT" xml:space="preserve">
+    <value>Security booking requires bank contact of the account.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_TXTYPE" xml:space="preserve">
+    <value>Security: Transaction type missing.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_QUANTITY" xml:space="preserve">
+    <value>Security: Quantity missing.</value>
+  </data>
+  <data name="Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND" xml:space="preserve">
+    <value>Security: Quantity not allowed for dividend.</value>
+  </data>
+  <data name="Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT" xml:space="preserve">
+    <value>Security: Fees+taxes exceed amount.</value>
+  </data>
+  <data name="Validation_ENTRY_NEEDS_CHECK" xml:space="preserve">
+    <value>A check of the information is required.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Savings plan on savings account is not allowed.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_REACHED_INFO" xml:space="preserve">
+    <value>With the bookings in this statement, the savings goal of the savings plan '{0}' will be reached.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_EXCEEDS" xml:space="preserve">
+    <value>The planned bookings exceed the savings goal of the savings plan '{0}'.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_ARCHIVE_MISMATCH" xml:space="preserve">
+    <value>Savings plan '{0}' cannot be archived: Bookings do not exactly match the remaining amount.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_DUE" xml:space="preserve">
+    <value>Savings plan '{0}' is due (Due date: {1:d}).</value>
+  </data>
+  <data name="Budget_BudgetExceeded" xml:space="preserve">
+    <value>Budget exceeded (Target: {0}, Actual after: {1}).</value>
+  </data>
+  <data name="Budget_BudgetAlmostExhausted" xml:space="preserve">
+    <value>Budget almost exhausted (Target: {0}, Actual after: {1}).</value>
+  </data>
+  <data name="Budget_StronglyChanged" xml:space="preserve">
+    <value>Target achievement strongly changed (Δ Rate: {0}%).</value>
+  </data>
+  <data name="Budget_NoCriticalDeviation" xml:space="preserve">
+    <value>No critical deviation (Actual before: {0}, Actual after: {1}).</value>
+  </data>
+</root>

--- a/FinanceManager.Web/Resources/Pages.resx
+++ b/FinanceManager.Web/Resources/Pages.resx
@@ -2337,4 +2337,73 @@
   <data name="SetupUpdate_Th_Sha256" xml:space="preserve">
     <value>SHA-256</value>
   </data>
+  <data name="Validation_NO_ACCOUNT" xml:space="preserve">
+    <value>No account assigned.</value>
+  </data>
+  <data name="Validation_SPLIT_CYCLE_DETECTED" xml:space="preserve">
+    <value>[Split] Cycles detected in split connections.</value>
+  </data>
+  <data name="Validation_SPLIT_DRAFT_HAS_ACCOUNT" xml:space="preserve">
+    <value>Split draft must not have an account assigned.</value>
+  </data>
+  <data name="Validation_SPLIT_AMOUNT_MISMATCH" xml:space="preserve">
+    <value>Sum of split does not match original amount.</value>
+  </data>
+  <data name="Validation_ENTRY_NO_CONTACT" xml:space="preserve">
+    <value>No contact assigned.</value>
+  </data>
+  <data name="Validation_INTERMEDIARY_NO_SPLIT" xml:space="preserve">
+    <value>Payment service without further split.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_MISSING_FOR_SELF" xml:space="preserve">
+    <value>For self-transfer, a savings plan is recommended.</value>
+  </data>
+  <data name="Validation_SECURITY_ACCOUNT_NOT_ALLOWED" xml:space="preserve">
+    <value>Security processing is disabled for this account.</value>
+  </data>
+  <data name="Validation_SECURITY_INVALID_CONTACT" xml:space="preserve">
+    <value>Security booking requires bank contact of the account.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_TXTYPE" xml:space="preserve">
+    <value>Security: Transaction type missing.</value>
+  </data>
+  <data name="Validation_SECURITY_MISSING_QUANTITY" xml:space="preserve">
+    <value>Security: Quantity missing.</value>
+  </data>
+  <data name="Validation_SECURITY_QUANTITY_NOT_ALLOWED_FOR_DIVIDEND" xml:space="preserve">
+    <value>Security: Quantity not allowed for dividend.</value>
+  </data>
+  <data name="Validation_SECURITY_FEE_TAX_EXCEEDS_AMOUNT" xml:space="preserve">
+    <value>Security: Fees+taxes exceed amount.</value>
+  </data>
+  <data name="Validation_ENTRY_NEEDS_CHECK" xml:space="preserve">
+    <value>A check of the information is required.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_INVALID_ACCOUNT" xml:space="preserve">
+    <value>Savings plan on savings account is not allowed.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_REACHED_INFO" xml:space="preserve">
+    <value>With the bookings in this statement, the savings goal of the savings plan '{0}' will be reached.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_GOAL_EXCEEDS" xml:space="preserve">
+    <value>The planned bookings exceed the savings goal of the savings plan '{0}'.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_ARCHIVE_MISMATCH" xml:space="preserve">
+    <value>Savings plan '{0}' cannot be archived: Bookings do not exactly match the remaining amount.</value>
+  </data>
+  <data name="Validation_SAVINGSPLAN_DUE" xml:space="preserve">
+    <value>Savings plan '{0}' is due (Due date: {1:d}).</value>
+  </data>
+  <data name="Budget_BudgetExceeded" xml:space="preserve">
+    <value>Budget exceeded (Target: {0}, Actual after: {1}).</value>
+  </data>
+  <data name="Budget_BudgetAlmostExhausted" xml:space="preserve">
+    <value>Budget almost exhausted (Target: {0}, Actual after: {1}).</value>
+  </data>
+  <data name="Budget_StronglyChanged" xml:space="preserve">
+    <value>Target achievement strongly changed (Δ Rate: {0}%).</value>
+  </data>
+  <data name="Budget_NoCriticalDeviation" xml:space="preserve">
+    <value>No critical deviation (Actual before: {0}, Actual after: {1}).</value>
+  </data>
 </root>

--- a/FinanceManager.Web/Shared/QuickEdit/QuickEditTable.razor
+++ b/FinanceManager.Web/Shared/QuickEdit/QuickEditTable.razor
@@ -3,6 +3,8 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
 @using FinanceManager.Shared.Dtos.Statements
+@using System.Linq
+@using System.Collections.Generic
 @inject IServiceProvider ServiceProvider
 @inject IJSRuntime JS
 
@@ -119,15 +121,58 @@
             return null;
         }
 
-        return $"{highest.BudgetPurposeName} ({highest.BudgetPeriod}): {highest.Reason}";
+        var localizedReason = GetLocalizedMessage(highest.Reason);
+        return $"{highest.BudgetPurposeName} ({highest.BudgetPeriod}): {localizedReason}";
+    }
+
+    private string GetLocalizedMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return message;
+        }
+
+        // Check if the message contains a pipe separator (indicating translation key with parameters)
+        if (message.Contains('|'))
+        {
+            var parts = message.Split('|');
+            var key = parts[0];
+            var parameters = parts.Skip(1).ToArray();
+
+            // Try to get the localized string (need to get localizer from service provider)
+            var localizer = ServiceProvider.GetService<Microsoft.Extensions.Localization.IStringLocalizer<FinanceManager.Web.Pages>>();
+            var localizedString = localizer?[key];
+            if (localizedString != null && !localizedString.ResourceNotFound)
+            {
+                // Format the message with parameters
+                try
+                {
+                    var formattedParams = new List<object>();
+                    foreach (var p in parameters)
+                    {
+                        formattedParams.Add(p);
+                    }
+                    
+                    return string.Format(localizedString, formattedParams.ToArray());
+                }
+                catch (FormatException)
+                {
+                    // If formatting fails, return the key as fallback
+                    return message;
+                }
+            }
+        }
+        
+        // If no translation key format or translation not found, return the original message
+        return message;
     }
 }
 
 @{
     var vm = ViewModel as FinanceManager.Web.ViewModels.StatementDrafts.StatementDraftEntriesListViewModel;
     var records = vm?.Records ?? new List<FinanceManager.Web.ViewModels.Common.ListRecord>();
-    Microsoft.Extensions.Localization.IStringLocalizer<Pages>? localizer = null;
-    try { localizer = ServiceProvider.GetService<Microsoft.Extensions.Localization.IStringLocalizer<Pages>>(); } catch { }
+    Microsoft.Extensions.Localization.IStringLocalizer<FinanceManager.Web.Pages>? localizer = null;
+    try { localizer = ServiceProvider.GetService<Microsoft.Extensions.Localization.IStringLocalizer<FinanceManager.Web.Pages>>(); } catch { }
     // If the ViewModel requested focusing first invalid row, consume the id and focus client-side
     var focusId = (vm as FinanceManager.Web.ViewModels.StatementDrafts.StatementDraftEntriesListViewModel)?.ConsumeFocusFirstInvalid();
     if (focusId != null)

--- a/FinanceManager.Web/ViewModels/StatementDrafts/StatementDraftEntriesListViewModel.cs
+++ b/FinanceManager.Web/ViewModels/StatementDrafts/StatementDraftEntriesListViewModel.cs
@@ -1,5 +1,7 @@
 using FinanceManager.Shared;
 using Microsoft.Extensions.Localization;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace FinanceManager.Web.ViewModels.StatementDrafts;
 
@@ -669,22 +671,100 @@ internal sealed class StatementDraftEntriesListViewModel : BaseListViewModel<Sta
                         severityLocalized = m.Severity ?? string.Empty;
                     }
 
-                    // try to map common English message texts to resource keys (e.g. "Invalid date format")
-                    string normalized = string.Empty;
+                    // First check if the message is a direct translation key (e.g. "Validation_ENTRY_NO_CONTACT")
+                    string msgLocalized = string.Empty;
                     if (!string.IsNullOrWhiteSpace(m.Message))
                     {
-                        var partsWords = m.Message.Split(new[] { ' ', '\t', '\r', '\n', '-', '_' }, StringSplitOptions.RemoveEmptyEntries);
-                        normalized = string.Concat(partsWords.Select(w => char.ToUpperInvariant(w[0]) + (w.Length > 1 ? w.Substring(1) : string.Empty)));
+                        // Check if the message contains a pipe separator (indicating translation key with parameters)
+                        if (m.Message.Contains('|'))
+                        {
+                            var keyParts = m.Message.Split('|');
+                            var key = keyParts[0];
+                            var parameters = keyParts.Skip(1).ToArray();
+
+                            // Try to get the localized string
+                            try
+                            {
+                                var localizedString = L?[key];
+                                if (localizedString != null && !localizedString.ResourceNotFound && localizedString.Value != null)
+                                {
+                                    // Format the message with parameters
+                                    try
+                                    {
+                                        var formattedParams = new List<object>();
+                                        foreach (var p in parameters)
+                                        {
+                                            // Try to parse as DateTime for date formatting
+                                            if (DateTime.TryParse(p, out var dateValue))
+                                            {
+                                                formattedParams.Add(dateValue);
+                                            }
+                                            else
+                                            {
+                                                formattedParams.Add(p);
+                                            }
+                                        }
+                                        
+                                        msgLocalized = string.Format(localizedString.Value, formattedParams.ToArray());
+                                    }
+                                    catch (FormatException)
+                                    {
+                                        // If formatting fails, use the key as fallback
+                                        msgLocalized = m.Message;
+                                    }
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                // If localization fails, use the original message as fallback
+                                msgLocalized = m.Message;
+                            }
+                        }
+                        else
+                        {
+                            // Simple translation key without parameters
+                            try
+                            {
+                                var localizedString = L?[m.Message];
+                                if (localizedString != null && !localizedString.ResourceNotFound && localizedString.Value != null)
+                                {
+                                    msgLocalized = localizedString.Value;
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                // If localization fails, use the original message as fallback
+                                msgLocalized = m.Message;
+                            }
+                        }
                     }
 
-                    string msgLocalized = string.Empty;
-                    if (!string.IsNullOrWhiteSpace(normalized))
+                    // If direct translation didn't work, try the old normalization approach
+                    if (string.IsNullOrWhiteSpace(msgLocalized))
                     {
-                        var msgKey = $"Validation_Message_{normalized}";
-                        var candidate = L[msgKey].Value;
-                        if (!string.IsNullOrWhiteSpace(candidate) && candidate != msgKey)
+                        try
                         {
-                            msgLocalized = candidate;
+                            string normalized = string.Empty;
+                            if (!string.IsNullOrWhiteSpace(m.Message))
+                            {
+                                var partsWords = m.Message.Split(new[] { ' ', '\t', '\r', '\n', '-', '_' }, StringSplitOptions.RemoveEmptyEntries);
+                                normalized = string.Concat(partsWords.Select(w => char.ToUpperInvariant(w[0]) + (w.Length > 1 ? w.Substring(1) : string.Empty)));
+                            }
+
+                            if (!string.IsNullOrWhiteSpace(normalized))
+                            {
+                                var msgKey = $"Validation_Message_{normalized}";
+                                var candidate = L?[msgKey]?.Value;
+                                if (!string.IsNullOrWhiteSpace(candidate) && candidate != msgKey)
+                                {
+                                    msgLocalized = candidate;
+                                }
+                            }
+                        }
+                        catch (Exception)
+                        {
+                            // If normalization fails, use the original message as fallback
+                            msgLocalized = m.Message ?? string.Empty;
                         }
                     }
 


### PR DESCRIPTION
## Commits

- `522f563` fix: Implement proper translation for validation messages and budget impact messages

Closes #232