### PR TITLE
Budgetbericht für Kategoriebasierte Budgets mit Gesamtbudgetierung zeigt keine Istwerte.

### DIFF
--- a/FinanceManager.Infrastructure/Budget/BudgetReportService.cs
+++ b/FinanceManager.Infrastructure/Budget/BudgetReportService.cs
@@ -680,20 +680,35 @@ public sealed class BudgetReportService : IBudgetReportService
                 foreach (var r in positiveRulesCat) AllocateCategoryRule(r);
                 foreach (var r in negativeRulesCat) AllocateCategoryRule(r);
 
-                // remaining postings: if there are category rules with patterns, they become unbudgeted
-                // if there are NO category rules with patterns, allocate to purposes based on contact group
-                var categoryRulesHavePatterns = originalCategoryRules.Any(r => !string.IsNullOrEmpty(r.PurposePattern));
+                // remaining postings: allocate to purposes based on contact group if:
+                // - there are NO category rules, OR
+                // - the purpose is ContactGroup-based and has a category rule
+                // Otherwise, they become unbudgeted.
                 foreach (var left in postingsForCategory)
                 {
-                    if (!categoryRulesHavePatterns && left.BudgetPurposeId.HasValue)
+                    if (left.BudgetPurposeId.HasValue)
                     {
-                        var key = left.BudgetPurposeId.Value;
-                        if (!allocated.TryGetValue(key, out var postingsList))
+                        var purpose = purposesInCat.FirstOrDefault(p => p.Id == left.BudgetPurposeId.Value);
+                        var isContactGroupPurpose = purpose?.SourceType == BudgetSourceType.ContactGroup;
+                        
+                        if (originalCategoryRules.Count == 0 || (isContactGroupPurpose && originalCategoryRules.Count > 0))
                         {
-                            postingsList = new List<BudgetReportPostingRawDataDto>();
-                            allocated[key] = postingsList;
+                            var key = left.BudgetPurposeId.Value;
+                            if (!allocated.TryGetValue(key, out var postingsList))
+                            {
+                                postingsList = new List<BudgetReportPostingRawDataDto>();
+                                allocated[key] = postingsList;
+                            }
+                            postingsList.Add(left with { IsValuedForBudgetPurpose = true });
                         }
-                        postingsList.Add(left with { IsValuedForBudgetPurpose = true });
+                        else
+                        {
+                            unbudgetedList.Add(left with
+                            {
+                                BudgetCategoryId = null,
+                                BudgetPurposeId = null
+                            });
+                        }
                     }
                     else
                     {

--- a/FinanceManager.Infrastructure/Budget/BudgetReportService.cs
+++ b/FinanceManager.Infrastructure/Budget/BudgetReportService.cs
@@ -553,7 +553,7 @@ public sealed class BudgetReportService : IBudgetReportService
                                 postingsList = new List<BudgetReportPostingRawDataDto>();
                                 allocated[key] = postingsList;
                             }
-                            postingsList.Add(candidate);
+                            postingsList.Add(candidate with { IsValuedForBudgetPurpose = true });
                         }
 
                         rulesForCategory.Remove(rule);
@@ -564,6 +564,9 @@ public sealed class BudgetReportService : IBudgetReportService
 
                 var positiveRulesCat = rulesForCategory.Where(r => r.Amount > 0).OrderByDescending(r => r.Amount).ToList();
                 var negativeRulesCat = rulesForCategory.Where(r => r.Amount < 0).OrderBy(r => r.Amount).ToList();
+                
+                // store original rules for pattern check
+                var originalCategoryRules = categoryRules.ToList();
 
                 void AllocateCategoryRule(BudgetRuleDto rule)
                 {
@@ -586,7 +589,7 @@ public sealed class BudgetReportService : IBudgetReportService
                                     postsForPurpose = new List<BudgetReportPostingRawDataDto>();
                                     allocated[targetPurposeId] = postsForPurpose;
                                 }
-                                postsForPurpose.Add(p);
+                                postsForPurpose.Add(p with { IsValuedForBudgetPurpose = true });
                                 }
 
                                 remaining -= p.Amount;
@@ -603,7 +606,7 @@ public sealed class BudgetReportService : IBudgetReportService
                                     postsForPurpose2 = new List<BudgetReportPostingRawDataDto>();
                                     allocated[targetPurposeId] = postsForPurpose2;
                                 }
-                                postsForPurpose2.Add(allocatedPart);
+                                postsForPurpose2.Add(allocatedPart with { IsValuedForBudgetPurpose = true });
                                 }
 
                                 var remainingAmount = p.Amount - remaining;
@@ -638,7 +641,7 @@ public sealed class BudgetReportService : IBudgetReportService
                                         list = new List<BudgetReportPostingRawDataDto>();
                                         allocated[targetPurposeId] = list;
                                     }
-                                    list.Add(p);
+                                    list.Add(p with { IsValuedForBudgetPurpose = true });
                                 }
 
                                 remainingAbs -= pAbs;
@@ -655,7 +658,7 @@ public sealed class BudgetReportService : IBudgetReportService
                                         list = new List<BudgetReportPostingRawDataDto>();
                                         allocated[targetPurposeId] = list;
                                     }
-                                    list.Add(allocatedPart);
+                                    list.Add(allocatedPart with { IsValuedForBudgetPurpose = true });
                                 }
 
                                 var remainingAmount = p.Amount + remainingAbs; // negative
@@ -677,14 +680,29 @@ public sealed class BudgetReportService : IBudgetReportService
                 foreach (var r in positiveRulesCat) AllocateCategoryRule(r);
                 foreach (var r in negativeRulesCat) AllocateCategoryRule(r);
 
-                // remaining postings become unbudgeted within this category
+                // remaining postings: if there are category rules with patterns, they become unbudgeted
+                // if there are NO category rules with patterns, allocate to purposes based on contact group
+                var categoryRulesHavePatterns = originalCategoryRules.Any(r => !string.IsNullOrEmpty(r.PurposePattern));
                 foreach (var left in postingsForCategory)
                 {
-                    unbudgetedList.Add(left with
+                    if (!categoryRulesHavePatterns && left.BudgetPurposeId.HasValue)
                     {
-                        BudgetCategoryId = null,
-                        BudgetPurposeId = null
-                    });
+                        var key = left.BudgetPurposeId.Value;
+                        if (!allocated.TryGetValue(key, out var postingsList))
+                        {
+                            postingsList = new List<BudgetReportPostingRawDataDto>();
+                            allocated[key] = postingsList;
+                        }
+                        postingsList.Add(left with { IsValuedForBudgetPurpose = true });
+                    }
+                    else
+                    {
+                        unbudgetedList.Add(left with
+                        {
+                            BudgetCategoryId = null,
+                            BudgetPurposeId = null
+                        });
+                    }
                     postingDtos.RemoveAll(x => x.PostingId == left.PostingId);
                 }
 
@@ -704,6 +722,7 @@ public sealed class BudgetReportService : IBudgetReportService
                         BudgetSourceType = pur.SourceType,
                         SourceId = pur.SourceId,
                         SourceName = pur.SourceName ?? string.Empty,
+                        ValuationType = pur.ValuationType,
                         Postings = posts?.ToArray() ?? Array.Empty<BudgetReportPostingRawDataDto>()
                     });
                 }

--- a/FinanceManager.Tests/Infrastructure/Budget/BudgetReportServiceRawDataTests.cs
+++ b/FinanceManager.Tests/Infrastructure/Budget/BudgetReportServiceRawDataTests.cs
@@ -707,7 +707,7 @@ public sealed class BudgetReportServiceRawDataTests
     /// Ensures category-level budget rules show actual values for purposes with contact group assignments.
     /// </summary>
     [Fact]
-    public async Task GetRawDataAsync_ShouldShowActualValues_WhenCategoryHasBudgetRuleAndPurposesHaveContactGroups()
+    public async Task GetRawDataAsync_ShouldShowActualValues_WhenCategoryHasBudgetRuleAndPurposesAreContactGroupBased()
     {
         var ownerUserId = Guid.NewGuid();
         var bakeryCategoryId = Guid.NewGuid();
@@ -879,7 +879,182 @@ public sealed class BudgetReportServiceRawDataTests
         var bakeryPurposeResult = rawCategory.Purposes.Single(x => x.PurposeId == bakeryPurposeId);
         var restaurantPurposeResult = rawCategory.Purposes.Single(x => x.PurposeId == restaurantPurposeId);
 
-        // Verify that actual values are shown for both purposes
+        // With a category rule and ContactGroup-based purposes, postings should be allocated to purposes
+        bakeryPurposeResult.Postings.Should().ContainSingle(x => x.PostingId == bakeryPostingId);
+        restaurantPurposeResult.Postings.Should().ContainSingle(x => x.PostingId == restaurantPostingId);
+
+        // Verify that the postings are valued for budget purpose
+        bakeryPurposeResult.Postings.Single().IsValuedForBudgetPurpose.Should().BeTrue();
+        restaurantPurposeResult.Postings.Single().IsValuedForBudgetPurpose.Should().BeTrue();
+
+        // Verify that there are no unbudgeted postings
+        result.UnbudgetedPostings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetRawDataAsync_ShouldShowActualValues_WhenCategoryHasNoBudgetRuleAndPurposesHaveContactGroups()
+    {
+        // This test verifies that when a category has NO budget rules,
+        // postings are allocated to purposes based on contact group assignments
+        var ownerUserId = Guid.NewGuid();
+        var from = new DateOnly(2026, 1, 1);
+        var to = new DateOnly(2026, 1, 31);
+
+        var budgetCategoryId = Guid.NewGuid();
+        var bakeryCategoryId = Guid.NewGuid();
+        var restaurantCategoryId = Guid.NewGuid();
+        var bakeryPurposeId = Guid.NewGuid();
+        var restaurantPurposeId = Guid.NewGuid();
+        var bakeryContactId = Guid.NewGuid();
+        var restaurantContactId = Guid.NewGuid();
+        var bakeryPostingId = Guid.NewGuid();
+        var restaurantPostingId = Guid.NewGuid();
+
+        var bakeryPurpose = new BudgetPurposeOverviewDto(
+            bakeryPurposeId,
+            ownerUserId,
+            "Bäckereien",
+            null,
+            BudgetSourceType.ContactGroup,
+            bakeryCategoryId,
+            1,
+            0m,
+            0m,
+            0m,
+            null,
+            null,
+            budgetCategoryId,
+            "Verpflegung",
+            BudgetValuationType.TotalBudget);
+
+        var restaurantPurpose = new BudgetPurposeOverviewDto(
+            restaurantPurposeId,
+            ownerUserId,
+            "Gastronomie",
+            null,
+            BudgetSourceType.ContactGroup,
+            restaurantCategoryId,
+            1,
+            0m,
+            0m,
+            0m,
+            null,
+            null,
+            budgetCategoryId,
+            "Verpflegung",
+            BudgetValuationType.TotalBudget);
+
+        var category = new BudgetCategoryOverviewDto(
+            budgetCategoryId,
+            "Verpflegung",
+            0m,
+            0m,
+            0m,
+            2);
+
+        var bakeryContact = new ContactDto(
+            bakeryContactId,
+            "Bäckerei",
+            ContactType.Organization,
+            bakeryCategoryId,
+            null,
+            false,
+            null);
+
+        var restaurantContact = new ContactDto(
+            restaurantContactId,
+            "Restaurant",
+            ContactType.Organization,
+            restaurantCategoryId,
+            null,
+            false,
+            null);
+
+        var postings = new[]
+        {
+            CreateContactPosting(
+                bakeryPostingId,
+                bakeryContactId,
+                new DateTime(2026, 1, 15),
+                -150m,
+                "Brötchen"),
+            CreateContactPosting(
+                restaurantPostingId,
+                restaurantContactId,
+                new DateTime(2026, 1, 20),
+                -200m,
+                "Mittagessen")
+        };
+
+        var purposeService = new Mock<IBudgetPurposeService>();
+        purposeService
+            .Setup(x => x.ListOverviewAsync(ownerUserId, 0, 5000, null, null, from, to, null, It.IsAny<CancellationToken>(), BudgetReportDateBasis.BookingDate))
+            .ReturnsAsync(new[] { bakeryPurpose, restaurantPurpose });
+
+        var categoryService = new Mock<IBudgetCategoryService>();
+        categoryService
+            .Setup(x => x.ListOverviewAsync(ownerUserId, from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { category });
+
+        var ruleService = new Mock<IBudgetRuleService>();
+        ruleService
+            .Setup(x => x.ListByPurposeAsync(ownerUserId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<BudgetRuleDto>());
+        ruleService
+            .Setup(x => x.ListByCategoryAsync(ownerUserId, budgetCategoryId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<BudgetRuleDto>()); // NO category rules
+
+        var postingsService = new Mock<IPostingsQueryService>();
+        postingsService
+            .Setup(x => x.GetContactPostingsAsync(bakeryContactId, 0, 5000, null, from.ToDateTime(TimeOnly.MinValue), to.ToDateTime(TimeOnly.MaxValue), ownerUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { postings[0] });
+        postingsService
+            .Setup(x => x.GetContactPostingsAsync(restaurantContactId, 0, 5000, null, from.ToDateTime(TimeOnly.MinValue), to.ToDateTime(TimeOnly.MaxValue), ownerUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { postings[1] });
+
+        var contactService = new Mock<IContactService>();
+        contactService
+            .Setup(x => x.ListAsync(ownerUserId, 0, 5000, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { bakeryContact, restaurantContact });
+
+        var savingsPlanService = new Mock<ISavingsPlanService>();
+        savingsPlanService
+            .Setup(x => x.ListAsync(ownerUserId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SavingsPlanDto>());
+
+        var securityService = new Mock<ISecurityService>();
+        securityService
+            .Setup(x => x.ListAsync(ownerUserId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SecurityDto>());
+
+        var cacheService = new Mock<IReportCacheService>();
+        cacheService
+            .Setup(x => x.GetBudgetReportRawDataAsync(ownerUserId, from, to, BudgetReportDateBasis.BookingDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BudgetReportRawDataDto?)null);
+        cacheService
+            .Setup(x => x.SetBudgetReportRawDataAsync(ownerUserId, from, to, BudgetReportDateBasis.BookingDate, It.IsAny<BudgetReportRawDataDto>(), false, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = new BudgetReportService(
+            purposeService.Object,
+            categoryService.Object,
+            ruleService.Object,
+            postingsService.Object,
+            contactService.Object,
+            savingsPlanService.Object,
+            securityService.Object,
+            cacheService.Object);
+
+        var result = await sut.GetRawDataAsync(ownerUserId, from, to, BudgetReportDateBasis.BookingDate, CancellationToken.None);
+
+        result.Categories.Should().ContainSingle(x => x.CategoryId == budgetCategoryId);
+        var rawCategory = result.Categories.Single(x => x.CategoryId == budgetCategoryId);
+        rawCategory.Purposes.Should().HaveCount(2);
+
+        var bakeryPurposeResult = rawCategory.Purposes.Single(x => x.PurposeId == bakeryPurposeId);
+        var restaurantPurposeResult = rawCategory.Purposes.Single(x => x.PurposeId == restaurantPurposeId);
+
+        // Without category rules, postings should be allocated to purposes based on contact group
         bakeryPurposeResult.Postings.Should().ContainSingle(x => x.PostingId == bakeryPostingId);
         restaurantPurposeResult.Postings.Should().ContainSingle(x => x.PostingId == restaurantPostingId);
 

--- a/FinanceManager.Tests/Infrastructure/Budget/BudgetReportServiceRawDataTests.cs
+++ b/FinanceManager.Tests/Infrastructure/Budget/BudgetReportServiceRawDataTests.cs
@@ -702,4 +702,192 @@ public sealed class BudgetReportServiceRawDataTests
             null,
             null);
     }
+
+    /// <summary>
+    /// Ensures category-level budget rules show actual values for purposes with contact group assignments.
+    /// </summary>
+    [Fact]
+    public async Task GetRawDataAsync_ShouldShowActualValues_WhenCategoryHasBudgetRuleAndPurposesHaveContactGroups()
+    {
+        var ownerUserId = Guid.NewGuid();
+        var bakeryCategoryId = Guid.NewGuid();
+        var restaurantCategoryId = Guid.NewGuid();
+        var bakeryContactId = Guid.NewGuid();
+        var restaurantContactId = Guid.NewGuid();
+        var budgetCategoryId = Guid.NewGuid();
+        var bakeryPurposeId = Guid.NewGuid();
+        var restaurantPurposeId = Guid.NewGuid();
+        var from = new DateOnly(2026, 1, 1);
+        var to = new DateOnly(2026, 1, 31);
+        var bakeryPostingId = Guid.NewGuid();
+        var restaurantPostingId = Guid.NewGuid();
+
+        var category = new BudgetCategoryOverviewDto(
+            budgetCategoryId,
+            "Verpflegung",
+            -500m,
+            0m,
+            -500m,
+            2);
+
+        var bakeryPurpose = new BudgetPurposeOverviewDto(
+            bakeryPurposeId,
+            ownerUserId,
+            "Bäckereien",
+            null,
+            BudgetSourceType.ContactGroup,
+            bakeryCategoryId,
+            0,
+            0m,
+            0m,
+            0m,
+            "Bäckereien",
+            null,
+            budgetCategoryId,
+            "Verpflegung",
+            BudgetValuationType.ExactPostings);
+
+        var restaurantPurpose = new BudgetPurposeOverviewDto(
+            restaurantPurposeId,
+            ownerUserId,
+            "Gastronomie",
+            null,
+            BudgetSourceType.ContactGroup,
+            restaurantCategoryId,
+            0,
+            0m,
+            0m,
+            0m,
+            "Gastronomie",
+            null,
+            budgetCategoryId,
+            "Verpflegung",
+            BudgetValuationType.ExactPostings);
+
+        var categoryRule = new BudgetRuleDto(
+            Guid.NewGuid(),
+            ownerUserId,
+            null,
+            budgetCategoryId,
+            -500m,
+            BudgetIntervalType.Monthly,
+            null,
+            from,
+            null,
+            null,
+            false);
+
+        var bakeryContact = new ContactDto(
+            bakeryContactId,
+            "Bäckerei",
+            ContactType.Organization,
+            bakeryCategoryId,
+            null,
+            false,
+            null);
+
+        var restaurantContact = new ContactDto(
+            restaurantContactId,
+            "Restaurant",
+            ContactType.Organization,
+            restaurantCategoryId,
+            null,
+            false,
+            null);
+
+        var postings = new[]
+        {
+            CreateContactPosting(
+                bakeryPostingId,
+                bakeryContactId,
+                new DateTime(2026, 1, 15),
+                -150m,
+                "Brötchen"),
+            CreateContactPosting(
+                restaurantPostingId,
+                restaurantContactId,
+                new DateTime(2026, 1, 20),
+                -200m,
+                "Mittagessen")
+        };
+
+        var purposeService = new Mock<IBudgetPurposeService>();
+        purposeService
+            .Setup(x => x.ListOverviewAsync(ownerUserId, 0, 5000, null, null, from, to, null, It.IsAny<CancellationToken>(), BudgetReportDateBasis.BookingDate))
+            .ReturnsAsync(new[] { bakeryPurpose, restaurantPurpose });
+
+        var categoryService = new Mock<IBudgetCategoryService>();
+        categoryService
+            .Setup(x => x.ListOverviewAsync(ownerUserId, from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { category });
+
+        var ruleService = new Mock<IBudgetRuleService>();
+        ruleService
+            .Setup(x => x.ListByPurposeAsync(ownerUserId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<BudgetRuleDto>());
+        ruleService
+            .Setup(x => x.ListByCategoryAsync(ownerUserId, budgetCategoryId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { categoryRule });
+
+        var postingsService = new Mock<IPostingsQueryService>();
+        postingsService
+            .Setup(x => x.GetContactPostingsAsync(bakeryContactId, 0, 5000, null, from.ToDateTime(TimeOnly.MinValue), to.ToDateTime(TimeOnly.MaxValue), ownerUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { postings[0] });
+        postingsService
+            .Setup(x => x.GetContactPostingsAsync(restaurantContactId, 0, 5000, null, from.ToDateTime(TimeOnly.MinValue), to.ToDateTime(TimeOnly.MaxValue), ownerUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { postings[1] });
+
+        var contactService = new Mock<IContactService>();
+        contactService
+            .Setup(x => x.ListAsync(ownerUserId, 0, 5000, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { bakeryContact, restaurantContact });
+
+        var savingsPlanService = new Mock<ISavingsPlanService>();
+        savingsPlanService
+            .Setup(x => x.ListAsync(ownerUserId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SavingsPlanDto>());
+
+        var securityService = new Mock<ISecurityService>();
+        securityService
+            .Setup(x => x.ListAsync(ownerUserId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SecurityDto>());
+
+        var cacheService = new Mock<IReportCacheService>();
+        cacheService
+            .Setup(x => x.GetBudgetReportRawDataAsync(ownerUserId, from, to, BudgetReportDateBasis.BookingDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BudgetReportRawDataDto?)null);
+        cacheService
+            .Setup(x => x.SetBudgetReportRawDataAsync(ownerUserId, from, to, BudgetReportDateBasis.BookingDate, It.IsAny<BudgetReportRawDataDto>(), false, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = new BudgetReportService(
+            purposeService.Object,
+            categoryService.Object,
+            ruleService.Object,
+            postingsService.Object,
+            contactService.Object,
+            savingsPlanService.Object,
+            securityService.Object,
+            cacheService.Object);
+
+        var result = await sut.GetRawDataAsync(ownerUserId, from, to, BudgetReportDateBasis.BookingDate, CancellationToken.None);
+
+        result.Categories.Should().ContainSingle(x => x.CategoryId == budgetCategoryId);
+        var rawCategory = result.Categories.Single(x => x.CategoryId == budgetCategoryId);
+        rawCategory.Purposes.Should().HaveCount(2);
+
+        var bakeryPurposeResult = rawCategory.Purposes.Single(x => x.PurposeId == bakeryPurposeId);
+        var restaurantPurposeResult = rawCategory.Purposes.Single(x => x.PurposeId == restaurantPurposeId);
+
+        // Verify that actual values are shown for both purposes
+        bakeryPurposeResult.Postings.Should().ContainSingle(x => x.PostingId == bakeryPostingId);
+        restaurantPurposeResult.Postings.Should().ContainSingle(x => x.PostingId == restaurantPostingId);
+
+        // Verify that the postings are valued for budget purpose
+        bakeryPurposeResult.Postings.Single().IsValuedForBudgetPurpose.Should().BeTrue();
+        restaurantPurposeResult.Postings.Single().IsValuedForBudgetPurpose.Should().BeTrue();
+
+        // Verify that there are no unbudgeted postings
+        result.UnbudgetedPostings.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Commits

- `91091e8` fix: Ensure actual values are shown for ContactGroup-based purposes with category-level budget rules
- `6beae93` fix: Ensure actual values are shown for category-based budgets with total budgeting