### PR TITLE
feat: PR-Quell-Branch fuer master via Actions-Check erzwingen

### DIFF
--- a/.github/workflows/verify-pr-source.yml
+++ b/.github/workflows/verify-pr-source.yml
@@ -1,0 +1,16 @@
+name: Verify PR Source
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  verify-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Nur PRs aus staging erlauben
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "::error::PRs gegen master sind nur aus staging erlaubt (Quelle: ${{ github.head_ref }})."
+            exit 1
+          fi


### PR DESCRIPTION
Fuegt einen Required-Status-Check hinzu, der PRs gegen master ablehnt, sofern der Quell-Branch nicht staging ist. GitHub bietet dafuer keine native Branch-Protection-Option, daher die Durchsetzung per Workflow (github.head_ref-Pruefung). Muss in den Branch-Protection- Einstellungen fuer master als required Check hinterlegt werden.