### PR TITLE
feat: RC-Versionierung fuer Pushes nach staging einfuehren

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [master, staging]
     tags: ["v*"]
 
 permissions:

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -87,7 +87,7 @@ Feature-Branch
 ### 3. release.yml — Versionsverwaltung und Publikation
 
 **Auslöser:**
-- `push` zu `master`
+- `push` zu `master` oder `staging`
 - `push` eines Tags im Format `vX.Y.Z`
 
 **Schritte:**
@@ -103,6 +103,17 @@ Feature-Branch
 **Nicht blockiert durch:**
 - E2E-Test-Fehler (continue-on-error)
 - Manuelle Tags (haben Vorrang vor Auto-Versioning)
+
+**RC-Versionierung auf `staging`:**
+
+`staging` ist in `release.config.js` als Semantic-Release-Prerelease-Branch mit Identifier `RC` konfiguriert (`{ name: "staging", prerelease: "RC" }`). Jeder Push nach `staging` löst denselben release.yml-Ablauf wie `master` aus, erzeugt aber ein GitHub-Release mit `prerelease: true` statt eines stabilen Releases:
+
+- Die Zielversion (`X.Y.Z`) wird wie auf `master` aus allen Conventional Commits seit dem letzten stabilen Tag berechnet (höchster Schweregrad gewinnt: `feat` → minor, `fix` → patch, `breaking` → major).
+- Solange sich diese Zielversion nicht ändert, wird nur der RC-Zähler erhöht: `1.16.1-RC.1` → `1.16.1-RC.2` → …
+- Ändert sich die Zielversion (z. B. weil nach reinen Fixes nun ein `feat`-Commit dazukommt), springt die Version auf die neue Ziffer und der RC-Zähler startet bei 1: `1.16.1-RC.3` → `1.17.0-RC.1`.
+- Beim Merge nach `master` entfällt das `-RC.N`-Suffix; die zuletzt berechnete Version wird zum finalen, stabilen Release (z. B. `1.17.0-RC.4` → `1.17.0`).
+- Da Squash-Merge im Repository deaktiviert ist, bleiben alle einzelnen Commit-Typen beim Promotion-Merge `staging → master` erhalten — die auf `master` berechnete Version stimmt daher exakt mit der zuletzt erreichten RC-Zielversion überein.
+- Beide Branches teilen sich dieselbe repository-weite Concurrency-Gruppe (`release-${{ github.repository }}`), damit parallele Versionsberechnungen auf `master` und `staging` nicht dieselbe Tag-Historie gleichzeitig verändern.
 
 ## Quality Gates
 
@@ -147,8 +158,9 @@ Feature-Branch
    - test.yml läuft automatisch
    - Mindestens 1 Approval erforderlich
    - Alle Checks müssen grün sein
-7. **Merge:** "Squash and merge" oder "Create a merge commit" (je nach Projektvorgabe)
-8. **Automatische Promotion:** Nach dem Merge zu `staging` prüft `staging-to-master.yml`, ob ein PR zu `master` nötig ist
+7. **Merge:** "Create a merge commit" oder "Rebase and merge" (Squash-Merge ist im Repository deaktiviert, damit Conventional-Commit-Typen für Semantic Release erhalten bleiben)
+8. **RC-Release:** Der Merge nach `staging` löst release.yml aus und erzeugt/erhöht die RC-Version (z. B. `1.16.1-RC.1`)
+9. **Automatische Promotion:** Nach dem Merge zu `staging` prüft `staging-to-master.yml`, ob ein PR zu `master` nötig ist
 
 ### Hotfix-Prozess
 
@@ -162,10 +174,10 @@ Feature-Branch
 
 ### Release-Prozess
 
-1. **Automatisch:** Merge zu `master` löst release.yml aus
-2. **Versionierung:** Semantic Release aus Conventional Commits
-3. **Artefakte:** ZIP-Pakete für Windows und Linux werden erstellt
-4. **GitHub Release:** Automatisch veröffentlicht mit Update-Manifest
+1. **Automatisch:** Merge zu `staging` oder `master` löst release.yml aus
+2. **Versionierung:** Semantic Release aus Conventional Commits; auf `staging` als RC-Prerelease (`X.Y.Z-RC.N`), auf `master` als finales, stabiles Release
+3. **Artefakte:** ZIP-Pakete für Windows und Linux werden erstellt (für RC-Releases identisch zum stabilen Release-Prozess)
+4. **GitHub Release:** Automatisch veröffentlicht mit Update-Manifest; RC-Releases werden dabei als `prerelease: true` markiert
 
 ## Fehlersuche
 

--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ const releaseAssets = [...releaseAssetPaths, releaseAssetPath, releaseManifestPa
   .map((assetPath) => ({ path: assetPath, name: path.basename(assetPath) }));
 
 module.exports = {
-  branches: ["master"],
+  branches: ["master", { name: "staging", prerelease: "RC" }],
   tagFormat: "v${version}",
   plugins: [
     [

--- a/scripts/resolve-release-version.mjs
+++ b/scripts/resolve-release-version.mjs
@@ -3,8 +3,9 @@ import { appendFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
-const NEXT_RELEASE_PATTERN = /The next release version is\s+(\d+\.\d+\.\d+)/i;
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+const NEXT_RELEASE_PATTERN = /The next release version is\s+(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)/i;
+const AUTOMATIC_RELEASE_BRANCHES = ["master", "staging"];
 
 export function parseManualTag(tagName) {
   if (!tagName?.startsWith("v")) {
@@ -30,7 +31,7 @@ export function classifyWorkflowRef({ refType, refName }) {
     return { kind: "manual", version: parseManualTag(refName), tag: refName };
   }
 
-  if (refType === "branch" && refName === "master") {
+  if (refType === "branch" && AUTOMATIC_RELEASE_BRANCHES.includes(refName)) {
     return { kind: "automatic" };
   }
 

--- a/scripts/resolve-release-version.test.mjs
+++ b/scripts/resolve-release-version.test.mjs
@@ -63,8 +63,11 @@ test("rejects non-semantic manual tags", () => {
   assert.throws(() => parseManualTag("v02.3.4"), /valid vX\.Y\.Z/);
 });
 
-test("accepts only master for automatic releases", () => {
+test("accepts only master and staging for automatic releases", () => {
   assert.deepEqual(classifyWorkflowRef({ refType: "branch", refName: "master" }), {
+    kind: "automatic"
+  });
+  assert.deepEqual(classifyWorkflowRef({ refType: "branch", refName: "staging" }), {
     kind: "automatic"
   });
   assert.throws(
@@ -76,6 +79,26 @@ test("accepts only master for automatic releases", () => {
 test("extracts a version only when Semantic Release announces one", () => {
   assert.equal(parseNextReleaseVersion("The next release version is 3.4.5"), "3.4.5");
   assert.equal(parseNextReleaseVersion("There are no relevant changes"), null);
+});
+
+test("extracts a prerelease version announced for the staging RC channel", () => {
+  assert.equal(parseNextReleaseVersion("The next release version is 1.17.0-RC.1"), "1.17.0-RC.1");
+  assert.equal(parseNextReleaseVersion("The next release version is 1.16.1-RC.12"), "1.16.1-RC.12");
+});
+
+test("creates an RC release when Semantic Release resolves a staging prerelease", async () => {
+  const testEffects = effects({ runSemanticReleaseDryRun: () => "The next release version is 1.17.0-RC.1" });
+
+  await resolveReleaseVersion(environment({ refName: "staging" }), testEffects.dependencies);
+
+  assert.deepEqual(testEffects.output[0], {
+    released: "true",
+    reason: "semantic-release",
+    version: "1.17.0-RC.1",
+    tag: "v1.17.0-RC.1",
+    release_kind: "automatic",
+    release_action: "create"
+  });
 });
 
 test("creates a release for a manual tag without an existing release", async () => {


### PR DESCRIPTION
## Zusammenfassung
- `release.yml` wird jetzt auch bei Pushes nach `staging` ausgeloest (bisher nur `master` + `vX.Y.Z`-Tags).
- `release.config.js`: `staging` als Semantic-Release-Prerelease-Branch mit Identifier `RC` konfiguriert (`{ name: "staging", prerelease: "RC" }`).
- `scripts/resolve-release-version.mjs`: Versions-Regex um Prerelease-Suffixe erweitert (`X.Y.Z-RC.N`), da sie zuvor nur reine `X.Y.Z`-Versionen aus der Semantic-Release-Ausgabe erkannt hat und RC-Versionen sonst nie geparst worden waeren.
- `CI-CD.md`: RC-Versionierungs-Verhalten dokumentiert (Zielversion, RC-Zaehler-Logik, Verhalten beim Merge nach master).

## Verhalten
- Zielversion (`X.Y.Z`) wird wie bisher aus Conventional Commits seit dem letzten stabilen Tag berechnet.
- Bleibt die Zielversion gleich, erhoeht sich nur der RC-Zaehler: `1.16.1-RC.1` -> `1.16.1-RC.2`.
- Aendert sich die Zielversion (z. B. `fix` -> `feat` seit letztem stabilen Release), springt die Version und der RC-Zaehler startet neu bei 1: `1.16.1-RC.3` -> `1.17.0-RC.1`.
- Beim Merge nach `master` entfaellt das RC-Suffix, die zuletzt erreichte Version wird final veroeffentlicht.
- RC-Releases werden von `@semantic-release/github` automatisch als `prerelease: true` markiert (Standardverhalten fuer Prerelease-Branches), erscheinen also nicht unter "Latest release".
- Repository-weite Concurrency-Gruppe (`release-${{ github.repository }}`) bleibt bewusst geteilt zwischen `master` und `staging`, damit keine zwei Versionsberechnungen gleichzeitig gegen dieselbe Tag-Historie laufen.

## Test plan
- [x] `npm run test:release-version` (25/25 gruen, inkl. neuer Tests fuer `classifyWorkflowRef("staging")` und Prerelease-Parsing)
- [ ] Nach Merge: ersten echten Push nach `staging` beobachten und pruefen, dass ein `X.Y.Z-RC.1`-Release mit `prerelease: true` entsteht