### PR TITLE
fix: staging nach jeder master-Promotion automatisch zuruecksynchronisieren

### DIFF
--- a/.github/workflows/sync-staging-with-master.yml
+++ b/.github/workflows/sync-staging-with-master.yml
@@ -1,0 +1,46 @@
+name: Sync Staging with Master
+
+# Jede Promotion staging -> master erzeugt einen Merge-Commit, der ausschliesslich auf master
+# existiert (siehe staging-to-master.yml). Ohne Ruecksynchronisation faellt staging dadurch sofort
+# wieder hinter den zuletzt auf master vergebenen Release-Tag zurueck: Semantic Release auf staging
+# faende den Tag dann nicht mehr erreichbar und wuerde die naechste RC-Version auf Basis eines
+# aelteren Tags berechnen (zu niedrige Zielversion). Dieser Workflow merged master nach jedem Push
+# direkt zurueck nach staging, damit der jeweils neueste Release-Tag fuer kuenftige RC-Berechnungen
+# erreichbar bleibt.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-staging-with-master
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout staging
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: staging
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge master into staging
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin master
+          if git merge-base --is-ancestor origin/master HEAD; then
+            echo "staging already contains the latest master state, nothing to sync."
+            exit 0
+          fi
+          git merge --no-edit origin/master
+          git push origin HEAD:staging
+        shell: bash

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -29,6 +29,11 @@ Feature-Branch
                                   ├→ Semantic Release (Version-Bump)
                                   ├→ ZIP-Artefakt erstellen
                                   ├→ GitHub Release veröffentlichen
+                             ├→ sync-staging-with-master.yml (Push-Event auf master)
+                                  ↓
+                                  ├→ master zurück nach staging mergen
+                                  ├→ Damit bleibt der neue Release-Tag für künftige
+                                     RC-Berechnungen auf staging erreichbar
 ```
 
 ## Workflows
@@ -114,6 +119,21 @@ Feature-Branch
 - Beim Merge nach `master` entfällt das `-RC.N`-Suffix; die zuletzt berechnete Version wird zum finalen, stabilen Release (z. B. `1.17.0-RC.4` → `1.17.0`).
 - Da Squash-Merge im Repository deaktiviert ist, bleiben alle einzelnen Commit-Typen beim Promotion-Merge `staging → master` erhalten — die auf `master` berechnete Version stimmt daher exakt mit der zuletzt erreichten RC-Zielversion überein.
 - Beide Branches teilen sich dieselbe repository-weite Concurrency-Gruppe (`release-${{ github.repository }}`), damit parallele Versionsberechnungen auf `master` und `staging` nicht dieselbe Tag-Historie gleichzeitig verändern.
+
+### 4. sync-staging-with-master.yml — Rücksynchronisation nach master
+
+**Auslöser:**
+- `push` zu `master`
+
+**Hintergrund:** Jede Promotion `staging → master` erzeugt einen Merge-Commit, der ausschließlich auf `master` existiert (Standard-Merge-Verhalten von GitHub-PRs). Ohne Rücksynchronisation ist der dort gesetzte Release-Tag (z. B. `v1.16.0`) aus Sicht von `staging` nicht erreichbar — Semantic Release würde die nächste RC-Version dann fälschlich auf Basis eines älteren, noch erreichbaren Tags berechnen (zu niedrige Zielversion, siehe Fehlersuche unten).
+
+**Schritte:**
+1. Checkout von `staging`
+2. Prüfen, ob `master` bereits vollständig in `staging` enthalten ist (nichts zu tun, falls ja)
+3. `master` per Merge-Commit in `staging` einmergen
+4. Direkter Push nach `staging`
+
+**Voraussetzung:** Der ausführende Actor (`github-actions[bot]` via `GITHUB_TOKEN`) muss in den Branch-Protection-Rules/Rulesets von `staging` als Bypass für "Require a pull request before merging" hinterlegt sein, sonst schlägt der Push fehl.
 
 ## Quality Gates
 
@@ -230,6 +250,20 @@ Feature-Branch
 1. Manuell einen PR zu `master` erstellen und mergen
 2. Überprüfen, dass `test.yml` erfolgreich läuft
 3. Nach Merge sollte `master` auf dem Stand von `staging` sein
+
+### RC-Version auf staging ist niedriger als der letzte master-Release
+
+**Symptom:**
+- Der letzte stabile Release ist z. B. `v1.16.0`, ein Push nach `staging` erzeugt aber `v1.16.0-RC.1` statt des erwarteten `v1.16.1-RC.1` (oder eine andere Zielversion, die niedriger ist als erwartet)
+
+**Ursache:**
+- Der Release-Tag auf `master` sitzt auf einem Merge-Commit, der nur auf `master` existiert (Standard-Verhalten der Promotion-PR-Merges) und (noch) nicht per `sync-staging-with-master.yml` nach `staging` zurückgemerged wurde. Semantic Release findet den Tag dann auf `staging` nicht als erreichbar und berechnet die nächste Version auf Basis eines älteren, noch erreichbaren Tags.
+- Prüfen: `git merge-base --is-ancestor v1.16.0 origin/staging` (Exit-Code `1` = Tag ist kein Vorfahre von `staging`, Ursache bestätigt)
+
+**Lösung:**
+1. Prüfen, ob `sync-staging-with-master.yml` nach dem letzten `master`-Push erfolgreich gelaufen ist (`gh run list --workflow=sync-staging-with-master.yml`)
+2. Falls der Workflow fehlgeschlagen ist (typischerweise weil der Bot-Actor noch nicht als Bypass für "Require a pull request before merging" auf `staging` hinterlegt ist): Branch-Protection-Rule/Ruleset für `staging` entsprechend ergänzen
+3. Einmalig manuell nachholen: `master` lokal in `staging` mergen und pushen, danach läuft die Automatik wieder normal
 
 ### Release schlägt fehl
 


### PR DESCRIPTION
## Problem
Nach dem ersten echten Push nach staging (PR #258) entstand `v1.16.0-RC.1` statt des erwarteten `v1.16.1-RC.1`. Root Cause verifiziert per `semantic-release --dry-run --debug`:

- Der Release-Tag `v1.16.0` sitzt auf Commit `72dfe8c` (Merge-Commit von PR #255, der Promotion staging -> master), der **nur auf master existiert**.
- `git merge-base --is-ancestor v1.16.0 origin/staging` -> negativ, d. h. staging kann diesen Tag nicht sehen.
- Semantic Release faellt deshalb auf den naechstaelteren erreichbaren Tag zurueck (`v1.15.0`) und berechnet die Zielversion auf falscher Basis.

## Fix
- Neuer Workflow `sync-staging-with-master.yml`: merged master nach jedem Push automatisch zurueck nach staging, damit der jeweils neueste Release-Tag fuer kuenftige RC-Berechnungen erreichbar bleibt.
- Dieser PR merged zusaetzlich einmalig den aktuellen master-Stand nach staging, um die bestehende Divergenz aufzuloesen (`v1.16.0` ist danach wieder erreichbar).
- `CI-CD.md`: neuer Workflow-Abschnitt + Fehlersuche-Eintrag fuer dieses Symptom dokumentiert.

## Wichtig: Manuelle Voraussetzung
`sync-staging-with-master.yml` pusht direkt nach `staging` (kein PR). Damit das nicht an "Require a pull request before merging" scheitert, muss der ausfuehrende Actor (`github-actions[bot]`) in den Branch-Protection-Rules/Rulesets von `staging` als Bypass hinterlegt werden. Ohne diese Einstellung schlaegt der Workflow nach jeder master-Promotion fehl (Symptom + Loesung ist in CI-CD.md dokumentiert).

## Test plan
- [x] `git merge-base --is-ancestor v1.16.0 HEAD` nach dem Merge -> positiv (Tag wieder erreichbar)
- [ ] Branch-Protection-Bypass fuer den Bot-Actor auf staging einrichten
- [ ] Nach Merge: naechste master-Promotion beobachten und pruefen, dass sync-staging-with-master.yml erfolgreich laeuft und staging synchron haelt