### PR TITLE
fix: staging-Sync auf PR-basierten Ansatz umstellen

### DIFF
--- a/.github/workflows/sync-staging-with-master.yml
+++ b/.github/workflows/sync-staging-with-master.yml
@@ -4,16 +4,24 @@ name: Sync Staging with Master
 # existiert (siehe staging-to-master.yml). Ohne Ruecksynchronisation faellt staging dadurch sofort
 # wieder hinter den zuletzt auf master vergebenen Release-Tag zurueck: Semantic Release auf staging
 # faende den Tag dann nicht mehr erreichbar und wuerde die naechste RC-Version auf Basis eines
-# aelteren Tags berechnen (zu niedrige Zielversion). Dieser Workflow merged master nach jedem Push
-# direkt zurueck nach staging, damit der jeweils neueste Release-Tag fuer kuenftige RC-Berechnungen
-# erreichbar bleibt.
+# aelteren Tags berechnen (zu niedrige Zielversion). Dieser Workflow erstellt nach jedem Push nach
+# master automatisch einen PR master -> staging, analog zu staging-to-master.yml. PR-basiert statt
+# Direct-Push, weil klassische Branch-Protection-Rules keinen granularen Bypass fuer einzelne Actors
+# unterstuetzen (nur ein globaler "Include administrators"-Schalter, kein Bot-spezifischer Bypass).
+#
+# Wichtig: Der PR muss mit "Create a merge commit" gemergt werden, nicht mit "Rebase and merge" -
+# die Promotion-Merge-Commits auf master sind inhaltlich leer (reine History-Knoten) und wuerden
+# von einem Rebase beim Replay verworfen, wodurch staging trotz "erfolgreichem" Merge weiterhin
+# hinter master zurueckbleibt.
 
 on:
   push:
     branches: [master]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: write
+  issues: write
 
 concurrency:
   group: sync-staging-with-master
@@ -30,17 +38,39 @@ jobs:
         with:
           fetch-depth: 0
           ref: staging
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge master into staging
+      - name: Fetch master
+        run: git fetch origin master
+        shell: bash
+
+      - name: Check if staging is behind master
+        id: diff
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin master
-          if git merge-base --is-ancestor origin/master HEAD; then
-            echo "staging already contains the latest master state, nothing to sync."
-            exit 0
+          count=$(git rev-list HEAD..origin/master --count)
+          echo "commits_behind=$count" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Ensure automated-sync label exists
+        if: steps.diff.outputs.commits_behind != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh label create automated-sync --color "0E8A16" --description "Automatisierter Sync-PR von master nach staging" --force
+        shell: bash
+
+      - name: Create sync pull request
+        if: steps.diff.outputs.commits_behind != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh pr list --base staging --head master --state open --json number --jq 'length')
+          if [ "$existing" = "0" ]; then
+            gh pr create \
+              --base staging \
+              --head master \
+              --title "Sync staging with master" \
+              --body "Automatischer Sync-PR nach einer Promotion nach master. Bitte mit **Create a merge commit** mergen (nicht Rebase), damit der neue Release-Tag fuer kuenftige RC-Berechnungen auf staging erreichbar bleibt." \
+              --label "automated-sync"
+          else
+            echo "An open sync PR from master to staging already exists."
           fi
-          git merge --no-edit origin/master
-          git push origin HEAD:staging
         shell: bash

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -31,7 +31,8 @@ Feature-Branch
                                   ├→ GitHub Release veröffentlichen
                              ├→ sync-staging-with-master.yml (Push-Event auf master)
                                   ↓
-                                  ├→ master zurück nach staging mergen
+                                  ├→ Automatischer PR master → staging
+                                  ├→ Maintainer Review + Merge ("Create a merge commit")
                                   ├→ Damit bleibt der neue Release-Tag für künftige
                                      RC-Berechnungen auf staging erreichbar
 ```
@@ -130,10 +131,11 @@ Feature-Branch
 **Schritte:**
 1. Checkout von `staging`
 2. Prüfen, ob `master` bereits vollständig in `staging` enthalten ist (nichts zu tun, falls ja)
-3. `master` per Merge-Commit in `staging` einmergen
-4. Direkter Push nach `staging`
+3. Automatischen PR `master → staging` erstellen (analog zu `staging-to-master.yml`, Label `automated-sync`), sofern noch keiner offen ist
 
-**Voraussetzung:** Der ausführende Actor (`github-actions[bot]` via `GITHUB_TOKEN`) muss in den Branch-Protection-Rules/Rulesets von `staging` als Bypass für "Require a pull request before merging" hinterlegt sein, sonst schlägt der Push fehl.
+**Wichtig beim Mergen:** Dieser PR muss mit **"Create a merge commit"** gemergt werden, nicht mit "Rebase and merge". Die Promotion-Merge-Commits auf `master` sind inhaltlich leer (reine History-Knoten); ein Rebase verwirft sie beim Replay, wodurch `staging` trotz "erfolgreichem" Merge weiterhin hinter `master` zurückbleibt.
+
+**Warum PR-basiert statt direktem Push:** Klassische Branch-Protection-Rules unterstützen keinen granularen Bypass für einzelne Actors (nur den globalen "Include administrators"-Schalter) — ein Bot-Push würde an "Require a pull request before merging" scheitern. Der PR-basierte Ansatz braucht keine Sonderrechte.
 
 ## Quality Gates
 
@@ -261,9 +263,18 @@ Feature-Branch
 - Prüfen: `git merge-base --is-ancestor v1.16.0 origin/staging` (Exit-Code `1` = Tag ist kein Vorfahre von `staging`, Ursache bestätigt)
 
 **Lösung:**
-1. Prüfen, ob `sync-staging-with-master.yml` nach dem letzten `master`-Push erfolgreich gelaufen ist (`gh run list --workflow=sync-staging-with-master.yml`)
-2. Falls der Workflow fehlgeschlagen ist (typischerweise weil der Bot-Actor noch nicht als Bypass für "Require a pull request before merging" auf `staging` hinterlegt ist): Branch-Protection-Rule/Ruleset für `staging` entsprechend ergänzen
-3. Einmalig manuell nachholen: `master` lokal in `staging` mergen und pushen, danach läuft die Automatik wieder normal
+1. Prüfen, ob ein offener Sync-PR (`master → staging`, Label `automated-sync`) existiert: `gh pr list --base staging --head master`
+2. Diesen PR mit **"Create a merge commit"** mergen (nicht "Rebase and merge" — verwirft die inhaltsleeren Promotion-Merge-Commits, siehe unten)
+3. Falls kein PR existiert, obwohl `staging` erkennbar hinter `master` liegt: `gh run list --workflow=sync-staging-with-master.yml` prüfen, ob der Workflow fehlgeschlagen ist
+
+### staging bleibt nach dem Merge des Sync-PRs weiterhin "N commits behind master"
+
+**Ursache:**
+- Der Sync-PR wurde mit "Rebase and merge" gemergt. Die Promotion-Merge-Commits auf `master` (z. B. `Merge pull request #255 from martin-stromberg/staging`) enthalten selbst keine Dateiänderungen — beim Rebase werden inhaltsleere Commits beim Replay verworfen, wodurch effektiv nichts nach `staging` übertragen wird, obwohl GitHub den PR als gemergt anzeigt.
+
+**Lösung:**
+1. Erneut einen PR `master → staging` erstellen (oder den bestehenden Zustand direkt lokal prüfen: `git rev-list origin/staging..origin/master --count`)
+2. Dieses Mal zwingend **"Create a merge commit"** verwenden
 
 ### Release schlägt fehl
 


### PR DESCRIPTION
## Problem
Der bisherige Direct-Push-Ansatz aus PR #260 scheiterte in der Praxis: `sync-staging-with-master.yml` versuchte, direkt nach `staging` zu pushen, wurde aber von "Require a pull request before merging" blockiert. Klassische Branch-Protection-Rules (im Gegensatz zu Rulesets) unterstuetzen keinen granularen Bypass fuer einzelne Actors wie `github-actions[bot]` - nur einen globalen "Include administrators"-Schalter.

Der manuelle Workaround (PR master -> staging per Hand erstellen und mergen) funktionierte ebenfalls nicht zuverlaessig: Beim Mergen per "Rebase and merge" wurden die inhaltsleeren Promotion-Merge-Commits auf master beim Replay verworfen, sodass staging trotz "erfolgreich gemergtem" PR weiterhin hinter master zurueckblieb (beobachtet bei PR #262 und #263).

## Fix
- `sync-staging-with-master.yml` erstellt jetzt automatisch einen PR `master -> staging` (Label `automated-sync`), analog zum bereits etablierten Muster von `staging-to-master.yml`. Kein Bypass/Rulesets-Umbau noetig.
- CI-CD.md aktualisiert: Workflow-Beschreibung, expliziter Hinweis auf "Create a merge commit" statt Rebase, neuer Fehlersuche-Eintrag fuer das Rebase-Symptom.

## Test plan
- [ ] Nach Merge: naechste `master`-Promotion abwarten, pruefen dass ein PR `master -> staging` automatisch entsteht
- [ ] Diesen PR mit "Create a merge commit" mergen und pruefen, dass `staging` danach `git rev-list origin/staging..origin/master --count` = 0 zeigt