### PR TITLE
fix: doppelten Testlauf fuer automatisierte Promotion-/Sync-PRs vermeiden

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ concurrency:
 
 jobs:
   test:
+    # Automatisierte Promotion-/Sync-PRs (staging-to-master.yml, sync-staging-with-master.yml) haben
+    # als Head-Branch immer "staging" oder "master" - dieser Commit wurde bereits per "push"-Event auf
+    # dem jeweiligen Branch getestet, bevor der PR erstellt wurde. Ohne diese Bedingung liefe die
+    # gesamte Suite fuer denselben Commit ein zweites Mal (push + pull_request). Fuer normale
+    # Feature-Branch-PRs (Head-Ref != master/staging) bleibt der pull_request-Lauf unveraendert.
+    if: github.event_name == 'push' || (github.head_ref != 'master' && github.head_ref != 'staging')
     runs-on: windows-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Zusammenfassung
- `staging-to-master.yml` und `sync-staging-with-master.yml` erzeugen automatisierte PRs mit Head-Branch `staging` bzw. `master`.
- Diese Commits sind bereits durch den `push`-Trigger von `test.yml` vollstaendig getestet, bevor der PR entsteht.
- Der zusaetzliche `pull_request`-Lauf fuer genau diese beiden Faelle war eine reine Verdopplung der ~13-Minuten-Testsuite (windows-latest).
- Neue Job-Bedingung ueberspringt den `pull_request`-Lauf nur, wenn Head-Ref `master` oder `staging` ist. Feature-Branch-PRs sind unveraendert betroffen.

## Test plan
- [ ] Beobachten, dass der naechste automatisierte Promotion-PR (staging -> master) keinen zusaetzlichen `pull_request`-Testlauf mehr ausloest.
- [ ] Beobachten, dass der naechste automatisierte Sync-PR (master -> staging) keinen zusaetzlichen `pull_request`-Testlauf mehr ausloest und trotzdem mergebar bleibt (skipped required check zaehlt als erfuellt).
- [ ] Normale Feature-Branch-PRs weiterhin mit `pull_request`-Testlauf pruefen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)