### PR TITLE
Zurück-Navigation von Kontaktpostendetails korrigieren

### DIFF
--- a/FinanceManager.Infrastructure/FinanceManager.Infrastructure.csproj
+++ b/FinanceManager.Infrastructure/FinanceManager.Infrastructure.csproj
@@ -22,10 +22,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.21.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
     <PackageReference Include="PdfPig" Version="0.1.15" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.21.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />

--- a/FinanceManager.Tests.E2E/Helpers/SetupUpdateGateway.cs
+++ b/FinanceManager.Tests.E2E/Helpers/SetupUpdateGateway.cs
@@ -88,8 +88,8 @@ public sealed class SetupUpdateGateway
     public Task WaitForAvailableVersionAsync(string expectedVersion)
         => Microsoft.Playwright.Assertions.Expect(AvailableVersionValue).ToHaveTextAsync(expectedVersion, new() { Timeout = 15000 });
 
-    private ILocator StatusValue => _page.Locator("#setup-update-status-value");
-    private ILocator AvailableVersionValue => _page.Locator("#setup-update-available-version-value");
+    private ILocator StatusValue => _page.Locator("[data-testid='update-status-value']");
+    private ILocator AvailableVersionValue => _page.Locator("[data-testid='update-available-value']");
 
     private ILocator EnabledCheckbox => _page.Locator(".setup-update-tab [data-testid='update-enabled-checkbox']");
 

--- a/FinanceManager.Tests.E2E/Helpers/SetupUpdateGateway.cs
+++ b/FinanceManager.Tests.E2E/Helpers/SetupUpdateGateway.cs
@@ -62,6 +62,12 @@ public sealed class SetupUpdateGateway
 
     public Task<bool> IsEnabledCheckedAsync() => EnabledCheckbox.IsCheckedAsync();
 
+    public async Task AllowChecksAnyTimeAsync()
+    {
+        await SourceCheckStartTimeInput.FillAsync("00:00");
+        await SourceCheckEndTimeInput.FillAsync("23:59");
+    }
+
     public async Task SaveSettingsAsync()
     {
         await SaveSettingsButton.ClickAsync();
@@ -95,7 +101,6 @@ public sealed class SetupUpdateGateway
 
     private ILocator SaveSettingsButton => _page.Locator("#Save");
 
-    private ILocator EnabledCheckbox => _page.Locator("#setup-update-enabled");
     private ILocator SourceCheckStartTimeInput => _page.Locator("#setup-update-source-check-start-time");
     private ILocator SourceCheckEndTimeInput => _page.Locator("#setup-update-source-check-end-time");
 

--- a/FinanceManager.Tests/FinanceManager.Tests.csproj
+++ b/FinanceManager.Tests/FinanceManager.Tests.csproj
@@ -24,11 +24,11 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.21.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="PdfPig" Version="0.1.15" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.21.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/FinanceManager.Web/FinanceManager.Web.csproj
+++ b/FinanceManager.Web/FinanceManager.Web.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.21.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
     <PackageReference Include="PdfPig" Version="0.1.15" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
@@ -76,7 +76,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.21.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FinanceManager.Web/FinanceManager.Web.csproj
+++ b/FinanceManager.Web/FinanceManager.Web.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />

--- a/FinanceManager.Web/ViewModels/Postings/Common/PostingsCardViewModel.cs
+++ b/FinanceManager.Web/ViewModels/Postings/Common/PostingsCardViewModel.cs
@@ -112,6 +112,9 @@ public sealed class PostingsCardViewModel : BaseCardViewModel<(string Key, strin
         var kindLower = Posting?.Kind.ToString().ToLowerInvariant() switch
         {
             "bank" => $"account/{Posting.AccountId}",
+            "contact" => $"contact/{Posting.ContactId}",
+            "savingsplan" => $"savings-plan/{Posting.SavingsPlanId}",
+            "security" => $"security/{Posting.SecurityId}",
             _ => Posting?.Kind.ToString().ToLowerInvariant()
         };
         var nav = new UiRibbonTab(localizer["Ribbon_Group_Navigation"].Value, new List<UiRibbonAction>


### PR DESCRIPTION
## Commits

- `24a82de` fix(web): Zurück-Navigation aus Posting-Card enthält wieder Kontakt-ID
- `d053ffd` chore(deps-dev): bump semantic-release from 25.0.8 to 25.0.9 (#288)
- `3ec079c` Merge branch 'staging' into dependabot/npm_and_yarn/staging/semantic-release-25.0.9
- `f340218` Bump Microsoft.EntityFrameworkCore.Design and Microsoft.Extensions.Caching.Memory (#293)
- `b0715f4` Merge branch 'staging' into dependabot/nuget/FinanceManager.Infrastructure/staging/multi-f6b0d3c468
- `9edfb3e` Bump AngleSharp from 1.7.0 to 1.7.1 (#289)
- `ec383b3` Merge branch 'staging' into dependabot/nuget/FinanceManager.Tests/staging/AngleSharp-1.7.1
- `9fdf52f` Bump Microsoft.AspNetCore.Mvc.Testing from 10.0.7 to 10.0.10 (#291)
- `3739a8a` Merge branch 'staging' into dependabot/nuget/FinanceManager.Tests.E2E/staging/Microsoft.AspNetCore.Mvc.Testing-10.0.10
- `bc07e52` Bump Microsoft.EntityFrameworkCore and Microsoft.Extensions.Caching.Memory (#292)
- `435b1c8` Merge branch 'staging' into dependabot/nuget/FinanceManager.Application/staging/multi-b34d5b1c76
- `4682c54` Bump bunit from 2.8.6 to 2.9.0 (#290)
- `036c86c` Merge branch 'staging' into dependabot/npm_and_yarn/staging/semantic-release-25.0.9
- `76a4811` Merge branch 'staging' into dependabot/nuget/FinanceManager.Tests/staging/AngleSharp-1.7.1
- `0e28d2a` Merge branch 'staging' into dependabot/nuget/FinanceManager.Tests.E2E/staging/Microsoft.AspNetCore.Mvc.Testing-10.0.10
- `578b856` Merge branch 'staging' into dependabot/nuget/FinanceManager.Application/staging/multi-b34d5b1c76
- `3915443` Merge branch 'staging' into dependabot/nuget/FinanceManager.Infrastructure/staging/multi-f6b0d3c468
- `2c054f3` Merge branch 'staging' into dependabot/nuget/FinanceManager.Tests/staging/bunit-2.9.0
- `d60827c` Canonical für security.txt (#296)
- `e04d1c7` Merge branch 'staging' into dependabot/nuget/FinanceManager.Tests/staging/bunit-2.9.0
- `1205d9f` Merge branch 'staging' into task/eb72b7adf9bb47f889cb7d81eda9c8f2-canonical-fuer-securitytxt
- `28ecbb0` Neue Version von msTools.Updater (#295)
- `3540461` feat: msTools.Updater v0.2.0 entfernen und Update-Setup-E2E-Tests reparieren
- `fbda833` chore: unbenutztes data-testid entfernen, Review-Iteration abschliessen
- `306796d` fix: Update-Setup-E2E-Tests reparieren (vorbestehender Fehler, unabhaengig von Versionsbereinigung)
- `302cccc` feat: canonical URL fuer security.txt verfeinern
- `f6103ad` feat: add configurable canonical for security.txt
- `a06e1b5` fix: Remove obsolete msTools.Updater v0.2.0 after successful migration
- `6f9e96b` plan: msTools.Updater v0.2.0 entfernen (v0.3.0 bereits aktiv)
- `6e855ab` plan: define canonical field for security.txt
- `597263b` Bump Microsoft.EntityFrameworkCore.Design and Microsoft.Extensions.Caching.Memory
- `23cb92a` Bump Microsoft.EntityFrameworkCore and Microsoft.Extensions.Caching.Memory
- `ffeca87` Bump Microsoft.AspNetCore.Mvc.Testing from 10.0.7 to 10.0.10
- `7bceb38` Budgetbericht neu strukturieren (#287)
- `f24c446` Bump bunit from 2.8.6 to 2.9.0
- `68ce894` Bump AngleSharp from 1.7.0 to 1.7.1
- `caeb4a1` chore(deps-dev): bump semantic-release from 25.0.8 to 25.0.9
- `4de8229` Merge branch 'staging' into task/bdbbeba77169489b8ffd80194f75430c-budgetbericht-neu-strukturiere
- `f7fe052` fix: Budgetbericht - Cache bei Drill-Down/Unbudgeted-Abruf wieder verwenden
- `582e8f8` fix: Budgetbericht - Regel-Perioden mit Ankertag ungleich 1 dem Monat des Periodenendes zuordnen
- `ad6c99b` test: Budgetbericht-Test auf vollstaendige Feldpruefung erweitert
- `50b90ab` docs: Testkommentare an den bereits behobenen Fehlerstand anpassen
- `338ebe1` fix: Budgetbericht - fehlende Vorperiode bei engem Berichtszeitraum ergaenzt
- `0c3bd02` test: Budgetbericht-Test mit anonymisierten, echten Buchungsdaten rekonstruiert bestaetigt Doppelfuehrungs-Fehler
- `103fba9` fix: Budgetbericht - Controller-Duplikation und Report-Cache-Konsistenz beheben
- `7a27e7e` fix: Budgetbericht - Posten nicht mehr doppelt gelistet
- `7830791` feat: Budgetbericht-Nacharbeiten abschliessen (Mapper-Testabdeckung)
- `c3546e6` security.txt (#285)
- `ccee4dc` feat: Budgetbericht objektorientiert neu strukturieren
- `e29fb27` feat: security.txt gemäß RFC 9116 mit Admin-Konfiguration und Mehrformat-Ausgabe
- `dae6eb3` plan: security.txt gemäß RFC 9116 mit Admin-Konfiguration und Mehrformat-Ausgabe
- `ee6deaf` plan: Budgetbericht objektorientiert neu strukturieren
- `eae8f8d` Neues Update lässt sich nicht installieren (#284)
- `5e4eb3f` chore: Alte Planungsdateien entfernt.
- `7816aa9` chore: Planungsverzeichnis fuer Update-Lock-Cleanup entfernen
- `d3697de` fix: Exception-Propagation in ValidateLockCleanupAsync absichern
- `e4b6c3e` feat: Update-Lock-Cleanup nach Installation validieren
- `2983060` docs: Update-Lock-Handling — Post-Installation-Validierung dokumentieren
- `2f6d5f1` plan: Umsetzungsplan an tatsaechliche Codebasis anpassen (msTools.Updater v0.3.0)
- `dd5e040` plan: Update-Lock-Statusinkonsistenz beheben (Reset schlaegt trotz aktivem Lock fehl)
- `f8d95ce` Merge branch 'master' into staging
- `6e93709` Budgetbericht für Kategoriebasierte Budgets mit Gesamtbudgetierung zeigt keine Istwerte. (#281)
- `84c57b3` Merge branch 'staging' into task/16ed41b5a299462bab1e9658ed3abdff-budgetbericht-fuer-kategorieba
- `af2e4e3` Fix budget report double-counting and display
- `eeb4f99` Sparplandetailansicht (#279)
- `2c52a10` fix: Deutsche Umlaute in Texten korrigieren
- `03ac3f8` fix: Restbetrag bei null ausblenden
- `beef2b3` feat: Sparplandetailansicht erweitern
- `5318f90` plan: Sparplandetailansicht erweitern
- `510a192` Update-Lock-Reset zeigt irrefuehrende Fehlermeldung (#277)
- `309abd5` feat: update-lock-reset-fehler differenzieren
- `f740f99` Sync staging with master (#276)
- `8c1a1e5` plan: update-lock-reset-fehler differenzieren
- `ed92fa2` resolve: Merge conflict - combine duplicate posting prevention with category rule logic
- `6ca018f` fix: Prevent duplicate posting allocation in budget report
- `0761a08` fix: Fix ContactDto parameter order and simplify test
- `5c96445` fix: Correct lambda variable name in posting allocation
- `fe51c93` fix: Ignore day for yearly budget interval calculation
- `29de90d` test: Add test for purpose rule with contact-based purpose
- `94643ca` fix: Ensure actual values are shown for ContactGroup-based purposes with category-level budget rules
- `91091e8` fix: Ensure actual values are shown for ContactGroup-based purposes with category-level budget rules
- `6beae93` fix: Ensure actual values are shown for category-based budgets with total budgeting

Closes #294